### PR TITLE
feat: load Supabase credentials from environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+SUPABASE_URL=https://your-supabase-url
+SUPABASE_PUBLISHABLE_KEY=your-publishable-key

--- a/.env.test
+++ b/.env.test
@@ -1,0 +1,2 @@
+SUPABASE_URL=https://example.supabase.co
+SUPABASE_PUBLISHABLE_KEY=test-public-anon-key

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ dist-ssr
 *.sln
 *.sw?
 .specstory/
+
+# Environment variables
+.env

--- a/README.md
+++ b/README.md
@@ -36,6 +36,17 @@ npm i
 npm run dev
 ```
 
+## Environment Variables
+
+Create a `.env` file based on `.env.example` and provide your Supabase credentials:
+
+```
+SUPABASE_URL=<your-supabase-url>
+SUPABASE_PUBLISHABLE_KEY=<your-publishable-key>
+```
+
+These variables are required for the application to connect to Supabase. Ensure your deployment pipeline also supplies these environment variables.
+
 **Edit a file directly in GitHub**
 
 - Navigate to the desired file(s).

--- a/src/integrations/supabase/client.test.ts
+++ b/src/integrations/supabase/client.test.ts
@@ -24,6 +24,11 @@ describe('Supabase Client', () => {
     expect(supabase.from).toBeDefined();
   });
 
+  it('uses environment variables for configuration', () => {
+    expect((supabase as any).supabaseUrl).toBe(process.env.SUPABASE_URL);
+    expect((supabase as any).supabaseKey).toBe(process.env.SUPABASE_PUBLISHABLE_KEY);
+  });
+
   it('has auth methods available', () => {
     expect(supabase.auth.signUp).toBeDefined();
     expect(supabase.auth.signInWithPassword).toBeDefined();

--- a/src/integrations/supabase/client.ts
+++ b/src/integrations/supabase/client.ts
@@ -2,8 +2,8 @@
 import { createClient } from '@supabase/supabase-js';
 import type { Database } from './types';
 
-const SUPABASE_URL = "https://fdtotoxhicqhoulckkgj.supabase.co";
-const SUPABASE_PUBLISHABLE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImZkdG90b3hoaWNxaG91bGNra2dqIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTQyMzM3MzAsImV4cCI6MjA2OTgwOTczMH0.sDuVB0Si1hcWBfQXOkUCoIXbpgUeqsjqzI5mG9FULYU";
+const SUPABASE_URL = process.env.SUPABASE_URL ?? '';
+const SUPABASE_PUBLISHABLE_KEY = process.env.SUPABASE_PUBLISHABLE_KEY ?? '';
 
 // Import the supabase client like this:
 // import { supabase } from "@/integrations/supabase/client";

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,23 +1,30 @@
-import { defineConfig } from "vite";
+import { defineConfig, loadEnv } from "vite";
 import react from "@vitejs/plugin-react-swc";
 import path from "path";
 import { componentTagger } from "lovable-tagger";
 
 // https://vitejs.dev/config/
-export default defineConfig(({ mode }) => ({
-  base: mode === 'production' ? '/promptscribe-mcp/' : '/',
-  server: {
-    host: "::",
-    port: 8080,
-  },
-  plugins: [
-    react(),
-    mode === 'development' &&
-    componentTagger(),
-  ].filter(Boolean),
-  resolve: {
-    alias: {
-      "@": path.resolve(__dirname, "./src"),
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), "");
+  Object.assign(process.env, env);
+  return {
+    base: mode === 'production' ? '/promptscribe-mcp/' : '/',
+    server: {
+      host: "::",
+      port: 8080,
     },
-  },
-}));
+    plugins: [
+      react(),
+      mode === 'development' &&
+      componentTagger(),
+    ].filter(Boolean),
+    resolve: {
+      alias: {
+        "@": path.resolve(__dirname, "./src"),
+      },
+    },
+    define: {
+      'process.env': env
+    }
+  };
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,19 +1,27 @@
 import { defineConfig } from 'vitest/config'
 import path from 'path'
+import { loadEnv } from 'vite'
 
-export default defineConfig({
-  resolve: {
-    alias: {
-      "@": path.resolve(__dirname, "./src"),
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), '')
+  Object.assign(process.env, env)
+  return {
+    resolve: {
+      alias: {
+        "@": path.resolve(__dirname, "./src"),
+      },
     },
-  },
-  test: {
-    globals: true,
-    environment: 'jsdom',
-    setupFiles: 'src/setupTests.ts',
-    coverage: {
-      provider: 'v8',
-      reporter: ['text', 'lcov', 'json'],
+    define: {
+      'process.env': env
     },
-  },
+    test: {
+      globals: true,
+      environment: 'jsdom',
+      setupFiles: 'src/setupTests.ts',
+      coverage: {
+        provider: 'v8',
+        reporter: ['text', 'lcov', 'json'],
+      },
+    },
+  }
 })


### PR DESCRIPTION
## Summary
- configure Vite and Vitest to load `.env` files and expose env vars
- read Supabase credentials from `process.env` and test the configuration
- document required Supabase environment variables

## Testing
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_68971331997c83289c68acd2d21b59d7