### PR TITLE
refactor: add TemplateData type and apply

### DIFF
--- a/src/components/templates/TemplateCard.test.tsx
+++ b/src/components/templates/TemplateCard.test.tsx
@@ -7,8 +7,14 @@ const mockTemplate = {
   name: 'Test Template',
   description: 'A test template description',
   template_data: {
-    arguments: [{ name: 'arg1' }, { name: 'arg2' }],
-    messages: [{ role: 'user', content: 'test' }, { role: 'assistant', content: 'response' }]
+    arguments: [
+      { name: 'arg1', description: '', required: false },
+      { name: 'arg2', description: '', required: false }
+    ],
+    messages: [
+      { role: 'user', content: 'test' },
+      { role: 'assistant', content: 'response' }
+    ]
   },
   is_public: true,
   created_at: '2023-01-01T00:00:00Z',

--- a/src/components/templates/TemplateEditor.tsx
+++ b/src/components/templates/TemplateEditor.tsx
@@ -8,7 +8,7 @@ import { Switch } from "@/components/ui/switch";
 import { useToast } from "@/hooks/use-toast";
 import { supabase } from "@/integrations/supabase/client";
 import { ArrowLeft, Save, Plus, Trash2 } from "lucide-react";
-import { MCPTemplate, TemplateMessage, TemplateArgument } from '@/types/template';
+import { MCPTemplate, TemplateMessage, TemplateArgument, TemplateData } from '@/types/template';
 import DeleteConfirmDialog from './DeleteConfirmDialog';
 
 interface TemplateEditorProps {
@@ -25,12 +25,12 @@ export default function TemplateEditor({ template, onSave, onCancel, onDelete }:
   const [isPublic, setIsPublic] = useState(template?.is_public || false);
   
   // Extract arguments and messages from template data
-  const templateData = template?.template_data || {};
+  const initialData: TemplateData = (template?.template_data ?? {}) as TemplateData;
   const [arguments_, setArguments] = useState<TemplateArgument[]>(
-    templateData.arguments || []
+    initialData.arguments ?? []
   );
   const [messages, setMessages] = useState<TemplateMessage[]>(
-    templateData.messages || [{ role: 'user', content: '{{prompt}}' }]
+    initialData.messages ?? [{ role: 'user', content: '{{prompt}}' }]
   );
   
   const [loading, setLoading] = useState(false);
@@ -109,9 +109,7 @@ export default function TemplateEditor({ template, onSave, onCancel, onDelete }:
       }
 
       // Build the template data object
-      const templateData = {
-        name: name.trim(),
-        description: description.trim() || "",
+      const templateData: TemplateData = {
         arguments: arguments_,
         messages: messages
       };
@@ -119,7 +117,7 @@ export default function TemplateEditor({ template, onSave, onCancel, onDelete }:
       const templatePayload = {
         name: name.trim(),
         description: description.trim() || null,
-        template_data: templateData as any,
+        template_data: templateData,
         is_public: isPublic,
         user_id: user.id
       };

--- a/src/components/templates/TemplateViewer.tsx
+++ b/src/components/templates/TemplateViewer.tsx
@@ -4,7 +4,7 @@ import { Badge } from "@/components/ui/badge";
 import { ArrowLeft, Copy, Globe, Lock, Edit, Trash2 } from "lucide-react";
 import { useToast } from "@/hooks/use-toast";
 import { User } from '@supabase/supabase-js';
-import { MCPTemplate } from '@/types/template';
+import { MCPTemplate, TemplateArgument, TemplateMessage } from '@/types/template';
 import { formatDetailedDate } from '@/lib/utils';
 import { useState } from 'react';
 import DeleteConfirmDialog from './DeleteConfirmDialog';
@@ -121,7 +121,7 @@ export default function TemplateViewer({ template, user, onBack, onEdit, onDelet
               </CardHeader>
               <CardContent>
                 <div className="space-y-2">
-                  {template.template_data.arguments.map((arg: any, index: number) => (
+                  {template.template_data.arguments!.map((arg: TemplateArgument, index: number) => (
                     <div key={index} className="p-2 bg-muted rounded text-sm">
                       <div className="font-semibold">{arg.name}</div>
                       {arg.description && (
@@ -165,7 +165,7 @@ export default function TemplateViewer({ template, user, onBack, onEdit, onDelet
               </CardHeader>
               <CardContent>
                 <div className="space-y-3">
-                  {template.template_data.messages.map((message: any, index: number) => (
+                  {template.template_data.messages!.map((message: TemplateMessage, index: number) => (
                     <div key={index} className="p-3 bg-muted rounded">
                       <div className="flex items-center gap-2 mb-2">
                         <Badge variant="outline" className="text-xs">

--- a/src/pages/Dashboard.test.tsx
+++ b/src/pages/Dashboard.test.tsx
@@ -75,7 +75,7 @@ const mockTemplate = {
   id: 'template-1',
   name: 'Test Template',
   description: 'A test template',
-  template_data: {},
+  template_data: { arguments: [], messages: [] },
   is_public: true,
   created_at: '2023-01-01',
   updated_at: '2023-01-01',
@@ -280,7 +280,7 @@ describe('Dashboard', () => {
             id: 'template-1',
             name: 'Test Template',
             description: 'Test Description',
-            template_data: { messages: [{ role: 'user', content: 'test' }] },
+            template_data: { arguments: [], messages: [{ role: 'user', content: 'test' }] },
             is_public: false,
             user_id: mockUser.id
           }],

--- a/src/types/template.test.ts
+++ b/src/types/template.test.ts
@@ -1,0 +1,13 @@
+import { describe, it, expectTypeOf } from 'vitest';
+import { TemplateData, TemplateArgument, TemplateMessage, MCPTemplate } from './template';
+
+describe('TemplateData type', () => {
+  it('has arguments and messages arrays', () => {
+    expectTypeOf<TemplateData>().toHaveProperty('arguments').toEqualTypeOf<TemplateArgument[] | undefined>();
+    expectTypeOf<TemplateData>().toHaveProperty('messages').toEqualTypeOf<TemplateMessage[] | undefined>();
+  });
+
+  it('is used in MCPTemplate', () => {
+    expectTypeOf<MCPTemplate>().toHaveProperty('template_data').toEqualTypeOf<TemplateData | null>();
+  });
+});

--- a/src/types/template.ts
+++ b/src/types/template.ts
@@ -1,14 +1,3 @@
-export interface MCPTemplate {
-  id: string;
-  name: string;
-  description: string | null;
-  template_data: any;
-  is_public: boolean;
-  created_at: string;
-  updated_at: string;
-  user_id: string;
-}
-
 export interface TemplateMessage {
   role: 'user' | 'assistant' | 'system';
   content: string;
@@ -18,4 +7,21 @@ export interface TemplateArgument {
   name: string;
   description: string;
   required: boolean;
+  type?: string;
+}
+
+export interface TemplateData {
+  arguments?: TemplateArgument[];
+  messages?: TemplateMessage[];
+}
+
+export interface MCPTemplate {
+  id: string;
+  name: string;
+  description: string | null;
+  template_data: TemplateData | null;
+  is_public: boolean;
+  created_at: string;
+  updated_at: string;
+  user_id: string;
 }


### PR DESCRIPTION
## Summary
- introduce TemplateData interface for template arguments and messages
- use TemplateData in template components and tests
- add type tests for TemplateData and MCPTemplate

## Testing
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_68971343427c8328ae4f3d109ed135b2