### PR TITLE
refactor: encapsulate Supabase access via service layer

### DIFF
--- a/src/components/auth/AuthForm.tsx
+++ b/src/components/auth/AuthForm.tsx
@@ -5,7 +5,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Label } from "@/components/ui/label";
 import { useToast } from "@/hooks/use-toast";
-import { supabase } from "@/integrations/supabase/client";
+import { signUp, signIn, resetPassword } from "@/services/authService";
 
 interface AuthFormProps {
   onAuthSuccess: () => void;
@@ -26,13 +26,7 @@ export default function AuthForm({ onAuthSuccess }: AuthFormProps) {
     try {
       const redirectUrl = `${window.location.origin}/`;
       
-      const { error } = await supabase.auth.signUp({
-        email,
-        password,
-        options: {
-          emailRedirectTo: redirectUrl
-        }
-      });
+      const { error } = await signUp(email, password, redirectUrl);
 
       if (error) {
         toast({
@@ -62,10 +56,7 @@ export default function AuthForm({ onAuthSuccess }: AuthFormProps) {
     setLoading(true);
 
     try {
-      const { error } = await supabase.auth.signInWithPassword({
-        email,
-        password
-      });
+      const { error } = await signIn(email, password);
 
       if (error) {
         toast({
@@ -92,9 +83,7 @@ export default function AuthForm({ onAuthSuccess }: AuthFormProps) {
     setLoading(true);
 
     try {
-      const { error } = await supabase.auth.resetPasswordForEmail(resetEmail, {
-        redirectTo: `${window.location.origin}/`
-      });
+      const { error } = await resetPassword(resetEmail, `${window.location.origin}/`);
 
       if (error) {
         toast({

--- a/src/components/auth/PasswordChangeForm.test.tsx
+++ b/src/components/auth/PasswordChangeForm.test.tsx
@@ -1,15 +1,10 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import PasswordChangeForm from './PasswordChangeForm';
-import { supabase } from '@/integrations/supabase/client';
+import { updatePassword } from '@/services/authService';
 
-// Mock the supabase client
-vi.mock('@/integrations/supabase/client', () => ({
-  supabase: {
-    auth: {
-      updateUser: vi.fn(),
-    }
-  }
+vi.mock('@/services/authService', () => ({
+  updatePassword: vi.fn(),
 }));
 
 // Mock the toast hook
@@ -112,7 +107,7 @@ describe('PasswordChangeForm', () => {
   });
 
   it('successfully changes password', async () => {
-    const mockUpdateUser = vi.mocked(supabase.auth.updateUser);
+    const mockUpdateUser = vi.mocked(updatePassword);
     mockUpdateUser.mockResolvedValue({ 
       data: { 
         user: {
@@ -144,9 +139,7 @@ describe('PasswordChangeForm', () => {
     fireEvent.click(screen.getByText('Update Password'));
     
     await waitFor(() => {
-      expect(mockUpdateUser).toHaveBeenCalledWith({
-        password: 'newpassword123'
-      });
+      expect(mockUpdateUser).toHaveBeenCalledWith('newpassword123');
     });
     
     expect(mockToast).toHaveBeenCalledWith({
@@ -158,7 +151,7 @@ describe('PasswordChangeForm', () => {
   });
 
   it('handles password update error', async () => {
-    const mockUpdateUser = vi.mocked(supabase.auth.updateUser);
+    const mockUpdateUser = vi.mocked(updatePassword);
     mockUpdateUser.mockResolvedValue({ 
       data: { user: null }, 
       error: { 
@@ -194,7 +187,7 @@ describe('PasswordChangeForm', () => {
   });
 
   it('handles unexpected errors', async () => {
-    const mockUpdateUser = vi.mocked(supabase.auth.updateUser);
+    const mockUpdateUser = vi.mocked(updatePassword);
     mockUpdateUser.mockRejectedValue(new Error('Network error'));
     
     render(
@@ -223,7 +216,7 @@ describe('PasswordChangeForm', () => {
   });
 
   it('disables form during loading', async () => {
-    const mockUpdateUser = vi.mocked(supabase.auth.updateUser);
+    const mockUpdateUser = vi.mocked(updatePassword);
     mockUpdateUser.mockImplementation(() => new Promise(resolve => setTimeout(resolve, 100)));
     
     render(

--- a/src/components/auth/PasswordChangeForm.tsx
+++ b/src/components/auth/PasswordChangeForm.tsx
@@ -4,7 +4,7 @@ import { Input } from "@/components/ui/input";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Label } from "@/components/ui/label";
 import { useToast } from "@/hooks/use-toast";
-import { supabase } from "@/integrations/supabase/client";
+import { updatePassword } from "@/services/authService";
 import { Lock } from "lucide-react";
 
 interface PasswordChangeFormProps {
@@ -42,9 +42,7 @@ export default function PasswordChangeForm({ onPasswordChanged, onCancel }: Pass
     setLoading(true);
 
     try {
-      const { error } = await supabase.auth.updateUser({
-        password: newPassword
-      });
+      const { error } = await updatePassword(newPassword);
 
       if (error) {
         toast({

--- a/src/components/templates/TemplateEditor.tsx
+++ b/src/components/templates/TemplateEditor.tsx
@@ -6,7 +6,8 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
 import { useToast } from "@/hooks/use-toast";
-import { supabase } from "@/integrations/supabase/client";
+import { getUser } from "@/services/authService";
+import { saveTemplate } from "@/services/templateService";
 import { ArrowLeft, Save, Plus, Trash2 } from "lucide-react";
 import { MCPTemplate, TemplateMessage, TemplateArgument, TemplateData } from '@/types/template';
 import DeleteConfirmDialog from './DeleteConfirmDialog';
@@ -98,7 +99,7 @@ export default function TemplateEditor({ template, onSave, onCancel, onDelete }:
     setLoading(true);
 
     try {
-      const { data: { user } } = await supabase.auth.getUser();
+      const { data: { user } } = await getUser();
       if (!user) {
         toast({
           variant: "destructive",
@@ -122,21 +123,7 @@ export default function TemplateEditor({ template, onSave, onCancel, onDelete }:
         user_id: user.id
       };
 
-      let error;
-      if (template?.id) {
-        // Update existing template
-        const { error: updateError } = await supabase
-          .from('prompt_templates')
-          .update(templatePayload)
-          .eq('id', template.id);
-        error = updateError;
-      } else {
-        // Create new template
-        const { error: insertError } = await supabase
-          .from('prompt_templates')
-          .insert([templatePayload]);
-        error = insertError;
-      }
+      const { error } = await saveTemplate(templatePayload, template?.id);
 
       if (error) {
         toast({

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -3,7 +3,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useToast } from "@/hooks/use-toast";
-import { supabase } from "@/integrations/supabase/client";
+import { fetchUserTemplates, fetchPublicTemplates, deleteTemplate } from "@/services/templateService";
 import { Plus, Search, LogOut } from "lucide-react";
 import TemplateCard from "@/components/templates/TemplateCard";
 import TemplateEditor from "@/components/templates/TemplateEditor";
@@ -38,20 +38,12 @@ export default function Dashboard({ user, onSignOut }: DashboardProps) {
     setLoading(true);
     try {
       // Fetch user's templates
-      const { data: userTemplates, error: userError } = await supabase
-        .from('prompt_templates')
-        .select('*')
-        .eq('user_id', user.id)
-        .order('updated_at', { ascending: false });
+      const { data: userTemplates, error: userError } = await fetchUserTemplates(user.id);
 
       if (userError) throw userError;
 
       // Fetch public templates (including user's own)
-      const { data: publicData, error: publicError } = await supabase
-        .from('prompt_templates')
-        .select('*')
-        .eq('is_public', true)
-        .order('updated_at', { ascending: false });
+      const { data: publicData, error: publicError } = await fetchPublicTemplates();
 
       if (publicError) throw publicError;
 
@@ -92,10 +84,7 @@ export default function Dashboard({ user, onSignOut }: DashboardProps) {
     if (!templateToDelete) return;
 
     try {
-      const { error } = await supabase
-        .from('prompt_templates')
-        .delete()
-        .eq('id', templateToDelete.id);
+      const { error } = await deleteTemplate(templateToDelete.id);
 
       if (error) throw error;
 

--- a/src/pages/Index.test.tsx
+++ b/src/pages/Index.test.tsx
@@ -2,17 +2,12 @@ import { render, screen, waitFor, act, fireEvent } from '@testing-library/react'
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { BrowserRouter } from 'react-router-dom';
 import Index from './Index';
-import { supabase } from '@/integrations/supabase/client';
+import { getSession, onAuthStateChange, signOut } from '@/services/authService';
 
-// Mock the supabase client
-vi.mock('@/integrations/supabase/client', () => ({
-  supabase: {
-    auth: {
-      onAuthStateChange: vi.fn(),
-      getSession: vi.fn(),
-      signOut: vi.fn(),
-    }
-  }
+vi.mock('@/services/authService', () => ({
+  getSession: vi.fn(),
+  onAuthStateChange: vi.fn(),
+  signOut: vi.fn(),
 }));
 
 // Mock the components
@@ -75,16 +70,14 @@ describe('Index', () => {
     mockOnAuthStateChange = vi.fn(() => ({
       data: { subscription: { unsubscribe: vi.fn() } }
     }));
-    
-    mockGetSession = vi.fn(() => 
-      Promise.resolve({ data: { session: null } })
-    );
-    
+
+    mockGetSession = vi.fn(() => Promise.resolve({ data: { session: null } }));
+
     mockSignOut = vi.fn(() => Promise.resolve({ error: null }));
-    
-    vi.mocked(supabase.auth.onAuthStateChange).mockImplementation(mockOnAuthStateChange);
-    vi.mocked(supabase.auth.getSession).mockImplementation(mockGetSession);
-    vi.mocked(supabase.auth.signOut).mockImplementation(mockSignOut);
+
+    vi.mocked(onAuthStateChange).mockImplementation(mockOnAuthStateChange);
+    vi.mocked(getSession).mockImplementation(mockGetSession);
+    vi.mocked(signOut).mockImplementation(mockSignOut);
 
     // Clear URL parameters
     delete (window as any).location;

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import { User, Session } from '@supabase/supabase-js';
-import { supabase } from "@/integrations/supabase/client";
+import { getSession, onAuthStateChange, signOut } from "@/services/authService";
 import AuthForm from "@/components/auth/AuthForm";
 import Dashboard from "@/pages/Dashboard";
 import PasswordChangeForm from "@/components/auth/PasswordChangeForm";
@@ -17,7 +17,7 @@ const Index = () => {
     const initializeAuth = async () => {
       try {
         // Get initial session first
-        const { data: { session }, error } = await supabase.auth.getSession();
+        const { data: { session }, error } = await getSession();
         
         if (error) throw error;
         
@@ -48,7 +48,7 @@ const Index = () => {
     }
 
     // Set up auth state listener
-    const { data: { subscription } } = supabase.auth.onAuthStateChange(
+    const { data: { subscription } } = onAuthStateChange(
       (event, session) => {
         if (isMounted) {
           setSession(session);
@@ -77,7 +77,7 @@ const Index = () => {
   };
 
   const handleSignOut = async () => {
-    await supabase.auth.signOut();
+    await signOut();
     // Auth state will be updated automatically via the listener
   };
 
@@ -89,7 +89,7 @@ const Index = () => {
   const handlePasswordChangeCancel = () => {
     setShowPasswordChange(false);
     // Sign out the user if they cancel password change
-    supabase.auth.signOut();
+    signOut();
   };
 
   if (loading) {

--- a/src/services/authService.test.ts
+++ b/src/services/authService.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { supabase } from '@/integrations/supabase/client';
+import {
+  signUp,
+  signIn,
+  resetPassword,
+  updatePassword,
+  getSession,
+  onAuthStateChange,
+  signOut,
+  getUser,
+} from './authService';
+
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: {
+    auth: {
+      signUp: vi.fn(),
+      signInWithPassword: vi.fn(),
+      resetPasswordForEmail: vi.fn(),
+      updateUser: vi.fn(),
+      getSession: vi.fn(),
+      onAuthStateChange: vi.fn(),
+      signOut: vi.fn(),
+      getUser: vi.fn(),
+    },
+  },
+}));
+
+describe('authService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('signUp delegates to supabase', async () => {
+    const result = { data: {}, error: null } as any;
+    vi.mocked(supabase.auth.signUp).mockResolvedValue(result);
+    const response = await signUp('a@b.com', 'pass', 'redirect');
+    expect(supabase.auth.signUp).toHaveBeenCalledWith({
+      email: 'a@b.com',
+      password: 'pass',
+      options: { emailRedirectTo: 'redirect' },
+    });
+    expect(response).toBe(result);
+  });
+
+  it('signIn delegates to supabase', async () => {
+    const result = { data: {}, error: null } as any;
+    vi.mocked(supabase.auth.signInWithPassword).mockResolvedValue(result);
+    const response = await signIn('a@b.com', 'pass');
+    expect(supabase.auth.signInWithPassword).toHaveBeenCalledWith({
+      email: 'a@b.com',
+      password: 'pass',
+    });
+    expect(response).toBe(result);
+  });
+
+  it('resetPassword delegates to supabase', async () => {
+    const result = { data: {}, error: null } as any;
+    vi.mocked(supabase.auth.resetPasswordForEmail).mockResolvedValue(result);
+    const response = await resetPassword('a@b.com', 'redir');
+    expect(supabase.auth.resetPasswordForEmail).toHaveBeenCalledWith('a@b.com', { redirectTo: 'redir' });
+    expect(response).toBe(result);
+  });
+
+  it('updatePassword delegates to supabase', async () => {
+    const result = { data: {}, error: null } as any;
+    vi.mocked(supabase.auth.updateUser).mockResolvedValue(result);
+    const response = await updatePassword('newpass');
+    expect(supabase.auth.updateUser).toHaveBeenCalledWith({ password: 'newpass' });
+    expect(response).toBe(result);
+  });
+
+  it('getSession delegates to supabase', async () => {
+    const result = { data: { session: null }, error: null } as any;
+    vi.mocked(supabase.auth.getSession).mockResolvedValue(result);
+    const response = await getSession();
+    expect(supabase.auth.getSession).toHaveBeenCalled();
+    expect(response).toBe(result);
+  });
+
+  it('onAuthStateChange delegates to supabase', () => {
+    const subscription = { unsubscribe: vi.fn() };
+    const result = { data: { subscription } } as any;
+    const callback = vi.fn();
+    vi.mocked(supabase.auth.onAuthStateChange).mockReturnValue(result);
+    const response = onAuthStateChange(callback);
+    expect(supabase.auth.onAuthStateChange).toHaveBeenCalledWith(callback);
+    expect(response).toBe(result);
+  });
+
+  it('signOut delegates to supabase', async () => {
+    const result = { error: null } as any;
+    vi.mocked(supabase.auth.signOut).mockResolvedValue(result);
+    const response = await signOut();
+    expect(supabase.auth.signOut).toHaveBeenCalled();
+    expect(response).toBe(result);
+  });
+
+  it('getUser delegates to supabase', async () => {
+    const result = { data: { user: null }, error: null } as any;
+    vi.mocked(supabase.auth.getUser).mockResolvedValue(result);
+    const response = await getUser();
+    expect(supabase.auth.getUser).toHaveBeenCalled();
+    expect(response).toBe(result);
+  });
+});
+

--- a/src/services/authService.ts
+++ b/src/services/authService.ts
@@ -1,0 +1,38 @@
+import { AuthChangeEvent, Session } from '@supabase/supabase-js';
+import { supabase } from '@/integrations/supabase/client';
+
+export async function signUp(email: string, password: string, redirectUrl: string) {
+  return supabase.auth.signUp({
+    email,
+    password,
+    options: { emailRedirectTo: redirectUrl },
+  });
+}
+
+export async function signIn(email: string, password: string) {
+  return supabase.auth.signInWithPassword({ email, password });
+}
+
+export async function resetPassword(email: string, redirectTo: string) {
+  return supabase.auth.resetPasswordForEmail(email, { redirectTo });
+}
+
+export async function updatePassword(password: string) {
+  return supabase.auth.updateUser({ password });
+}
+
+export async function getSession() {
+  return supabase.auth.getSession();
+}
+
+export function onAuthStateChange(callback: (event: AuthChangeEvent, session: Session | null) => void) {
+  return supabase.auth.onAuthStateChange(callback);
+}
+
+export async function signOut() {
+  return supabase.auth.signOut();
+}
+
+export async function getUser() {
+  return supabase.auth.getUser();
+}

--- a/src/services/templateService.test.ts
+++ b/src/services/templateService.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { supabase } from '@/integrations/supabase/client';
+import {
+  fetchUserTemplates,
+  fetchPublicTemplates,
+  saveTemplate,
+  deleteTemplate,
+} from './templateService';
+
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: {
+    from: vi.fn(),
+  },
+}));
+
+describe('templateService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('fetchUserTemplates queries supabase correctly', async () => {
+    const order = vi.fn().mockResolvedValue({ data: [], error: null });
+    const eq = vi.fn(() => ({ order }));
+    const select = vi.fn(() => ({ eq }));
+    vi.mocked(supabase.from).mockReturnValue({ select } as any);
+
+    const result = await fetchUserTemplates('user-1');
+    expect(supabase.from).toHaveBeenCalledWith('prompt_templates');
+    expect(select).toHaveBeenCalledWith('*');
+    expect(eq).toHaveBeenCalledWith('user_id', 'user-1');
+    expect(order).toHaveBeenCalledWith('updated_at', { ascending: false });
+    expect(result).toEqual({ data: [], error: null });
+  });
+
+  it('fetchPublicTemplates queries supabase correctly', async () => {
+    const order = vi.fn().mockResolvedValue({ data: [], error: null });
+    const eq = vi.fn(() => ({ order }));
+    const select = vi.fn(() => ({ eq }));
+    vi.mocked(supabase.from).mockReturnValue({ select } as any);
+
+    const result = await fetchPublicTemplates();
+    expect(supabase.from).toHaveBeenCalledWith('prompt_templates');
+    expect(select).toHaveBeenCalledWith('*');
+    expect(eq).toHaveBeenCalledWith('is_public', true);
+    expect(order).toHaveBeenCalledWith('updated_at', { ascending: false });
+    expect(result).toEqual({ data: [], error: null });
+  });
+
+  it('saveTemplate inserts when no id', async () => {
+    const insert = vi.fn().mockResolvedValue({ error: null });
+    vi.mocked(supabase.from).mockReturnValue({ insert } as any);
+    const payload = { name: 't' };
+    const result = await saveTemplate(payload);
+    expect(supabase.from).toHaveBeenCalledWith('prompt_templates');
+    expect(insert).toHaveBeenCalledWith([payload]);
+    expect(result).toEqual({ error: null });
+  });
+
+  it('saveTemplate updates when id provided', async () => {
+    const eq = vi.fn().mockResolvedValue({ error: null });
+    const update = vi.fn(() => ({ eq }));
+    vi.mocked(supabase.from).mockReturnValue({ update } as any);
+    const payload = { name: 't' };
+    const result = await saveTemplate(payload, 'id-1');
+    expect(supabase.from).toHaveBeenCalledWith('prompt_templates');
+    expect(update).toHaveBeenCalledWith(payload);
+    expect(eq).toHaveBeenCalledWith('id', 'id-1');
+    expect(result).toEqual({ error: null });
+  });
+
+  it('deleteTemplate delegates to supabase', async () => {
+    const eq = vi.fn().mockResolvedValue({ error: null });
+    const del = vi.fn(() => ({ eq }));
+    vi.mocked(supabase.from).mockReturnValue({ delete: del } as any);
+
+    const result = await deleteTemplate('id-1');
+    expect(supabase.from).toHaveBeenCalledWith('prompt_templates');
+    expect(del).toHaveBeenCalled();
+    expect(eq).toHaveBeenCalledWith('id', 'id-1');
+    expect(result).toEqual({ error: null });
+  });
+});
+

--- a/src/services/templateService.ts
+++ b/src/services/templateService.ts
@@ -1,0 +1,34 @@
+import { supabase } from '@/integrations/supabase/client';
+
+export async function fetchUserTemplates(userId: string) {
+  return supabase
+    .from('prompt_templates')
+    .select('*')
+    .eq('user_id', userId)
+    .order('updated_at', { ascending: false });
+}
+
+export async function fetchPublicTemplates() {
+  return supabase
+    .from('prompt_templates')
+    .select('*')
+    .eq('is_public', true)
+    .order('updated_at', { ascending: false });
+}
+
+export async function saveTemplate(payload: any, id?: string) {
+  if (id) {
+    return supabase
+      .from('prompt_templates')
+      .update(payload)
+      .eq('id', id);
+  }
+  return supabase.from('prompt_templates').insert([payload]);
+}
+
+export async function deleteTemplate(id: string) {
+  return supabase
+    .from('prompt_templates')
+    .delete()
+    .eq('id', id);
+}


### PR DESCRIPTION
## Summary
- add authService and templateService modules wrapping Supabase operations
- refactor components to call services instead of Supabase client
- add tests for new service layer and adjust existing tests

## Testing
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_68972f16931c8328899ebcd73a6c34bd