### PR TITLE
refactor: centralize supabase API error handling

### DIFF
--- a/src/api/supabaseApi.test.ts
+++ b/src/api/supabaseApi.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect, vi } from 'vitest';
+import { handleRequest } from './supabaseApi';
+
+vi.mock('@/hooks/use-toast', () => ({
+  toast: vi.fn(),
+}));
+
+import { toast } from '@/hooks/use-toast';
+
+describe('handleRequest', () => {
+  it('returns data when request succeeds', async () => {
+    const promise = Promise.resolve({ data: { ok: true }, error: null });
+    const result = await handleRequest(promise, 'Failed');
+    expect(result).toEqual({ data: { ok: true }, error: null });
+    expect(toast).not.toHaveBeenCalled();
+  });
+
+  it('toasts and returns error when request fails', async () => {
+    const promise = Promise.resolve({ data: null, error: { message: 'bad' } });
+    const result = await handleRequest(promise, 'Failed');
+    expect(result).toEqual({ data: null, error: { message: 'bad' } });
+    expect(toast).toHaveBeenCalledWith({
+      variant: 'destructive',
+      title: 'Error',
+      description: 'Failed',
+    });
+  });
+});

--- a/src/api/supabaseApi.ts
+++ b/src/api/supabaseApi.ts
@@ -1,0 +1,20 @@
+import { toast } from '@/hooks/use-toast';
+
+export async function handleRequest<T>(
+  request: Promise<{ data: T | null; error: any }>,
+  errorMessage: string
+): Promise<{ data: T | null; error: any }>
+{
+  try {
+    const { data, error } = await request;
+    if (error) {
+      console.error(error);
+      toast({ variant: 'destructive', title: 'Error', description: errorMessage });
+    }
+    return { data: data ?? null, error };
+  } catch (error) {
+    console.error(error);
+    toast({ variant: 'destructive', title: 'Error', description: errorMessage });
+    return { data: null, error } as any;
+  }
+}

--- a/src/services/authService.test.ts
+++ b/src/services/authService.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { supabase } from '@/integrations/supabase/client';
+import { handleRequest } from '@/api/supabaseApi';
 import {
   signUp,
   signIn,
@@ -25,6 +26,9 @@ vi.mock('@/integrations/supabase/client', () => ({
     },
   },
 }));
+vi.mock('@/api/supabaseApi', () => ({
+  handleRequest: vi.fn(),
+}));
 
 describe('authService', () => {
   beforeEach(() => {
@@ -33,48 +37,63 @@ describe('authService', () => {
 
   it('signUp delegates to supabase', async () => {
     const result = { data: {}, error: null } as any;
-    vi.mocked(supabase.auth.signUp).mockResolvedValue(result);
+    const promise = Promise.resolve(result);
+    vi.mocked(supabase.auth.signUp).mockReturnValue(promise as any);
+    vi.mocked(handleRequest).mockResolvedValue(result);
     const response = await signUp('a@b.com', 'pass', 'redirect');
     expect(supabase.auth.signUp).toHaveBeenCalledWith({
       email: 'a@b.com',
       password: 'pass',
       options: { emailRedirectTo: 'redirect' },
     });
+    expect(handleRequest).toHaveBeenCalledWith(promise, 'Sign up failed');
     expect(response).toBe(result);
   });
 
   it('signIn delegates to supabase', async () => {
     const result = { data: {}, error: null } as any;
-    vi.mocked(supabase.auth.signInWithPassword).mockResolvedValue(result);
+    const promise = Promise.resolve(result);
+    vi.mocked(supabase.auth.signInWithPassword).mockReturnValue(promise as any);
+    vi.mocked(handleRequest).mockResolvedValue(result);
     const response = await signIn('a@b.com', 'pass');
     expect(supabase.auth.signInWithPassword).toHaveBeenCalledWith({
       email: 'a@b.com',
       password: 'pass',
     });
+    expect(handleRequest).toHaveBeenCalledWith(promise, 'Sign in failed');
     expect(response).toBe(result);
   });
 
   it('resetPassword delegates to supabase', async () => {
     const result = { data: {}, error: null } as any;
-    vi.mocked(supabase.auth.resetPasswordForEmail).mockResolvedValue(result);
+    const promise = Promise.resolve(result);
+    vi.mocked(supabase.auth.resetPasswordForEmail).mockReturnValue(promise as any);
+    vi.mocked(handleRequest).mockResolvedValue(result);
     const response = await resetPassword('a@b.com', 'redir');
     expect(supabase.auth.resetPasswordForEmail).toHaveBeenCalledWith('a@b.com', { redirectTo: 'redir' });
+    expect(handleRequest).toHaveBeenCalledWith(promise, 'Reset failed');
     expect(response).toBe(result);
   });
 
   it('updatePassword delegates to supabase', async () => {
     const result = { data: {}, error: null } as any;
-    vi.mocked(supabase.auth.updateUser).mockResolvedValue(result);
+    const promise = Promise.resolve(result);
+    vi.mocked(supabase.auth.updateUser).mockReturnValue(promise as any);
+    vi.mocked(handleRequest).mockResolvedValue(result);
     const response = await updatePassword('newpass');
     expect(supabase.auth.updateUser).toHaveBeenCalledWith({ password: 'newpass' });
+    expect(handleRequest).toHaveBeenCalledWith(promise, 'Password update failed');
     expect(response).toBe(result);
   });
 
   it('getSession delegates to supabase', async () => {
     const result = { data: { session: null }, error: null } as any;
-    vi.mocked(supabase.auth.getSession).mockResolvedValue(result);
+    const promise = Promise.resolve(result);
+    vi.mocked(supabase.auth.getSession).mockReturnValue(promise as any);
+    vi.mocked(handleRequest).mockResolvedValue(result);
     const response = await getSession();
     expect(supabase.auth.getSession).toHaveBeenCalled();
+    expect(handleRequest).toHaveBeenCalledWith(promise, 'Failed to get session');
     expect(response).toBe(result);
   });
 
@@ -90,17 +109,23 @@ describe('authService', () => {
 
   it('signOut delegates to supabase', async () => {
     const result = { error: null } as any;
-    vi.mocked(supabase.auth.signOut).mockResolvedValue(result);
+    const promise = Promise.resolve(result);
+    vi.mocked(supabase.auth.signOut).mockReturnValue(promise as any);
+    vi.mocked(handleRequest).mockResolvedValue(result);
     const response = await signOut();
     expect(supabase.auth.signOut).toHaveBeenCalled();
+    expect(handleRequest).toHaveBeenCalledWith(promise, 'Sign out failed');
     expect(response).toBe(result);
   });
 
   it('getUser delegates to supabase', async () => {
     const result = { data: { user: null }, error: null } as any;
-    vi.mocked(supabase.auth.getUser).mockResolvedValue(result);
+    const promise = Promise.resolve(result);
+    vi.mocked(supabase.auth.getUser).mockReturnValue(promise as any);
+    vi.mocked(handleRequest).mockResolvedValue(result);
     const response = await getUser();
     expect(supabase.auth.getUser).toHaveBeenCalled();
+    expect(handleRequest).toHaveBeenCalledWith(promise, 'Failed to get user');
     expect(response).toBe(result);
   });
 });

--- a/src/services/authService.ts
+++ b/src/services/authService.ts
@@ -1,28 +1,44 @@
 import { AuthChangeEvent, Session } from '@supabase/supabase-js';
 import { supabase } from '@/integrations/supabase/client';
+import { handleRequest } from '@/api/supabaseApi';
 
 export async function signUp(email: string, password: string, redirectUrl: string) {
-  return supabase.auth.signUp({
-    email,
-    password,
-    options: { emailRedirectTo: redirectUrl },
-  });
+  return handleRequest(
+    supabase.auth.signUp({
+      email,
+      password,
+      options: { emailRedirectTo: redirectUrl },
+    }),
+    'Sign up failed'
+  );
 }
 
 export async function signIn(email: string, password: string) {
-  return supabase.auth.signInWithPassword({ email, password });
+  return handleRequest(
+    supabase.auth.signInWithPassword({ email, password }),
+    'Sign in failed'
+  );
 }
 
 export async function resetPassword(email: string, redirectTo: string) {
-  return supabase.auth.resetPasswordForEmail(email, { redirectTo });
+  return handleRequest(
+    supabase.auth.resetPasswordForEmail(email, { redirectTo }),
+    'Reset failed'
+  );
 }
 
 export async function updatePassword(password: string) {
-  return supabase.auth.updateUser({ password });
+  return handleRequest(
+    supabase.auth.updateUser({ password }),
+    'Password update failed'
+  );
 }
 
 export async function getSession() {
-  return supabase.auth.getSession();
+  return handleRequest(
+    supabase.auth.getSession(),
+    'Failed to get session'
+  );
 }
 
 export function onAuthStateChange(callback: (event: AuthChangeEvent, session: Session | null) => void) {
@@ -30,9 +46,15 @@ export function onAuthStateChange(callback: (event: AuthChangeEvent, session: Se
 }
 
 export async function signOut() {
-  return supabase.auth.signOut();
+  return handleRequest(
+    supabase.auth.signOut(),
+    'Sign out failed'
+  );
 }
 
 export async function getUser() {
-  return supabase.auth.getUser();
+  return handleRequest(
+    supabase.auth.getUser(),
+    'Failed to get user'
+  );
 }

--- a/src/services/templateService.test.ts
+++ b/src/services/templateService.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { supabase } from '@/integrations/supabase/client';
+import { handleRequest } from '@/api/supabaseApi';
 import {
   fetchUserTemplates,
   fetchPublicTemplates,
@@ -12,6 +13,9 @@ vi.mock('@/integrations/supabase/client', () => ({
     from: vi.fn(),
   },
 }));
+vi.mock('@/api/supabaseApi', () => ({
+  handleRequest: vi.fn(),
+}));
 
 describe('templateService', () => {
   beforeEach(() => {
@@ -19,65 +23,85 @@ describe('templateService', () => {
   });
 
   it('fetchUserTemplates queries supabase correctly', async () => {
-    const order = vi.fn().mockResolvedValue({ data: [], error: null });
+    const result = { data: [], error: null } as any;
+    const promise = Promise.resolve(result);
+    const order = vi.fn(() => promise);
     const eq = vi.fn(() => ({ order }));
     const select = vi.fn(() => ({ eq }));
     vi.mocked(supabase.from).mockReturnValue({ select } as any);
+    vi.mocked(handleRequest).mockResolvedValue(result);
 
-    const result = await fetchUserTemplates('user-1');
+    const response = await fetchUserTemplates('user-1');
     expect(supabase.from).toHaveBeenCalledWith('prompt_templates');
     expect(select).toHaveBeenCalledWith('*');
     expect(eq).toHaveBeenCalledWith('user_id', 'user-1');
     expect(order).toHaveBeenCalledWith('updated_at', { ascending: false });
-    expect(result).toEqual({ data: [], error: null });
+    expect(handleRequest).toHaveBeenCalledWith(promise, 'Failed to load templates');
+    expect(response).toBe(result);
   });
 
   it('fetchPublicTemplates queries supabase correctly', async () => {
-    const order = vi.fn().mockResolvedValue({ data: [], error: null });
+    const result = { data: [], error: null } as any;
+    const promise = Promise.resolve(result);
+    const order = vi.fn(() => promise);
     const eq = vi.fn(() => ({ order }));
     const select = vi.fn(() => ({ eq }));
     vi.mocked(supabase.from).mockReturnValue({ select } as any);
+    vi.mocked(handleRequest).mockResolvedValue(result);
 
-    const result = await fetchPublicTemplates();
+    const response = await fetchPublicTemplates();
     expect(supabase.from).toHaveBeenCalledWith('prompt_templates');
     expect(select).toHaveBeenCalledWith('*');
     expect(eq).toHaveBeenCalledWith('is_public', true);
     expect(order).toHaveBeenCalledWith('updated_at', { ascending: false });
-    expect(result).toEqual({ data: [], error: null });
+    expect(handleRequest).toHaveBeenCalledWith(promise, 'Failed to load templates');
+    expect(response).toBe(result);
   });
 
   it('saveTemplate inserts when no id', async () => {
-    const insert = vi.fn().mockResolvedValue({ error: null });
+    const result = { error: null } as any;
+    const promise = Promise.resolve(result);
+    const insert = vi.fn(() => promise);
     vi.mocked(supabase.from).mockReturnValue({ insert } as any);
+    vi.mocked(handleRequest).mockResolvedValue(result);
     const payload = { name: 't' };
-    const result = await saveTemplate(payload);
+    const response = await saveTemplate(payload);
     expect(supabase.from).toHaveBeenCalledWith('prompt_templates');
     expect(insert).toHaveBeenCalledWith([payload]);
-    expect(result).toEqual({ error: null });
+    expect(handleRequest).toHaveBeenCalledWith(promise, 'Failed to save template');
+    expect(response).toBe(result);
   });
 
   it('saveTemplate updates when id provided', async () => {
-    const eq = vi.fn().mockResolvedValue({ error: null });
+    const result = { error: null } as any;
+    const promise = Promise.resolve(result);
+    const eq = vi.fn(() => promise);
     const update = vi.fn(() => ({ eq }));
     vi.mocked(supabase.from).mockReturnValue({ update } as any);
+    vi.mocked(handleRequest).mockResolvedValue(result);
     const payload = { name: 't' };
-    const result = await saveTemplate(payload, 'id-1');
+    const response = await saveTemplate(payload, 'id-1');
     expect(supabase.from).toHaveBeenCalledWith('prompt_templates');
     expect(update).toHaveBeenCalledWith(payload);
     expect(eq).toHaveBeenCalledWith('id', 'id-1');
-    expect(result).toEqual({ error: null });
+    expect(handleRequest).toHaveBeenCalledWith(promise, 'Failed to save template');
+    expect(response).toBe(result);
   });
 
   it('deleteTemplate delegates to supabase', async () => {
-    const eq = vi.fn().mockResolvedValue({ error: null });
+    const result = { error: null } as any;
+    const promise = Promise.resolve(result);
+    const eq = vi.fn(() => promise);
     const del = vi.fn(() => ({ eq }));
     vi.mocked(supabase.from).mockReturnValue({ delete: del } as any);
+    vi.mocked(handleRequest).mockResolvedValue(result);
 
-    const result = await deleteTemplate('id-1');
+    const response = await deleteTemplate('id-1');
     expect(supabase.from).toHaveBeenCalledWith('prompt_templates');
     expect(del).toHaveBeenCalled();
     expect(eq).toHaveBeenCalledWith('id', 'id-1');
-    expect(result).toEqual({ error: null });
+    expect(handleRequest).toHaveBeenCalledWith(promise, 'Failed to delete template');
+    expect(response).toBe(result);
   });
 });
 

--- a/src/services/templateService.ts
+++ b/src/services/templateService.ts
@@ -1,34 +1,50 @@
 import { supabase } from '@/integrations/supabase/client';
+import { handleRequest } from '@/api/supabaseApi';
 
 export async function fetchUserTemplates(userId: string) {
-  return supabase
-    .from('prompt_templates')
-    .select('*')
-    .eq('user_id', userId)
-    .order('updated_at', { ascending: false });
+  return handleRequest(
+    supabase
+      .from('prompt_templates')
+      .select('*')
+      .eq('user_id', userId)
+      .order('updated_at', { ascending: false }),
+    'Failed to load templates'
+  );
 }
 
 export async function fetchPublicTemplates() {
-  return supabase
-    .from('prompt_templates')
-    .select('*')
-    .eq('is_public', true)
-    .order('updated_at', { ascending: false });
+  return handleRequest(
+    supabase
+      .from('prompt_templates')
+      .select('*')
+      .eq('is_public', true)
+      .order('updated_at', { ascending: false }),
+    'Failed to load templates'
+  );
 }
 
 export async function saveTemplate(payload: any, id?: string) {
   if (id) {
-    return supabase
-      .from('prompt_templates')
-      .update(payload)
-      .eq('id', id);
+    return handleRequest(
+      supabase
+        .from('prompt_templates')
+        .update(payload)
+        .eq('id', id),
+      'Failed to save template'
+    );
   }
-  return supabase.from('prompt_templates').insert([payload]);
+  return handleRequest(
+    supabase.from('prompt_templates').insert([payload]),
+    'Failed to save template'
+  );
 }
 
 export async function deleteTemplate(id: string) {
-  return supabase
-    .from('prompt_templates')
-    .delete()
-    .eq('id', id);
+  return handleRequest(
+    supabase
+      .from('prompt_templates')
+      .delete()
+      .eq('id', id),
+    'Failed to delete template'
+  );
 }


### PR DESCRIPTION
## Summary
- add supabase API helper to normalize errors and surface toasts
- route auth and template services through centralized handler
- cover new helper and updated services with unit tests

## Testing
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_6897850f5a3c8328ad484d20ff3bff75