### PR TITLE
refactor: extract template editor logic into hook and subcomponent

### DIFF
--- a/src/components/templates/TemplateArgumentsEditor.tsx
+++ b/src/components/templates/TemplateArgumentsEditor.tsx
@@ -1,0 +1,84 @@
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+import { Plus, Trash2 } from "lucide-react";
+import { TemplateArgument } from '@/types/template';
+
+interface TemplateArgumentsEditorProps {
+  arguments_: TemplateArgument[];
+  addArgument: () => void;
+  removeArgument: (index: number) => void;
+  updateArgument: (
+    index: number,
+    field: keyof TemplateArgument,
+    value: string | boolean
+  ) => void;
+}
+
+export default function TemplateArgumentsEditor({
+  arguments_,
+  addArgument,
+  removeArgument,
+  updateArgument,
+}: TemplateArgumentsEditorProps) {
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-center justify-between">
+          <div>
+            <CardTitle>Arguments</CardTitle>
+            <CardDescription>
+              Define the variables that users can customize in this template
+            </CardDescription>
+          </div>
+          <Button onClick={addArgument} size="sm">
+            <Plus className="w-4 h-4 mr-2" />
+            Add Argument
+          </Button>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {arguments_.length === 0 ? (
+          <p className="text-muted-foreground text-center py-4">
+            No arguments defined. Arguments allow users to customize your template with variables like {"{{name}}"} or {"{{topic}}"}.
+          </p>
+        ) : (
+          arguments_.map((arg, index) => (
+            <div key={index} className="grid grid-cols-1 md:grid-cols-2 gap-4 p-4 border rounded-lg">
+              <div className="space-y-2">
+                <Label>Name *</Label>
+                <Input
+                  placeholder="e.g., topic, name, style"
+                  value={arg.name}
+                  onChange={(e) => updateArgument(index, 'name', e.target.value)}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label>Description</Label>
+                <Input
+                  placeholder="Describe this argument"
+                  value={arg.description}
+                  onChange={(e) => updateArgument(index, 'description', e.target.value)}
+                />
+              </div>
+              <div className="flex items-center justify-between md:col-span-2">
+                <div className="flex items-center space-x-2">
+                  <Switch
+                    checked={arg.required}
+                    onCheckedChange={(checked) => updateArgument(index, 'required', checked)}
+                  />
+                  <Label>Required</Label>
+                </div>
+                <Button variant="outline" size="sm" onClick={() => removeArgument(index)}>
+                  <Trash2 className="w-4 h-4" />
+                </Button>
+              </div>
+            </div>
+          ))
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/hooks/useTemplateEditor.ts
+++ b/src/hooks/useTemplateEditor.ts
@@ -1,0 +1,71 @@
+import { useState } from 'react';
+import { MCPTemplate, TemplateArgument, TemplateMessage, TemplateData } from '@/types/template';
+
+export function useTemplateEditor(initial?: MCPTemplate) {
+  const [name, setName] = useState(initial?.name ?? '');
+  const [description, setDescription] = useState(initial?.description ?? '');
+  const [isPublic, setIsPublic] = useState(initial?.is_public ?? false);
+
+  const initialData: TemplateData = (initial?.template_data ?? {}) as TemplateData;
+  const [arguments_, setArguments] = useState<TemplateArgument[]>(
+    initialData.arguments ?? []
+  );
+  const [messages, setMessages] = useState<TemplateMessage[]>(
+    initialData.messages ?? [{ role: 'user', content: '{{prompt}}' }]
+  );
+
+  const addArgument = () => {
+    setArguments([...arguments_, { name: '', description: '', required: false }]);
+  };
+
+  const removeArgument = (index: number) => {
+    setArguments(arguments_.filter((_, i) => i !== index));
+  };
+
+  const updateArgument = (
+    index: number,
+    field: keyof TemplateArgument,
+    value: string | boolean
+  ) => {
+    const updated = [...arguments_];
+    updated[index] = { ...updated[index], [field]: value };
+    setArguments(updated);
+  };
+
+  const addMessage = () => {
+    setMessages([...messages, { role: 'user', content: '' }]);
+  };
+
+  const removeMessage = (index: number) => {
+    setMessages(messages.filter((_, i) => i !== index));
+  };
+
+  const updateMessage = (
+    index: number,
+    field: keyof TemplateMessage,
+    value: string
+  ) => {
+    const updated = [...messages];
+    updated[index] = { ...updated[index], [field]: value };
+    setMessages(updated);
+  };
+
+  return {
+    name,
+    setName,
+    description,
+    setDescription,
+    isPublic,
+    setIsPublic,
+    arguments_,
+    addArgument,
+    removeArgument,
+    updateArgument,
+    messages,
+    addMessage,
+    removeMessage,
+    updateMessage,
+  };
+}
+
+export default useTemplateEditor;


### PR DESCRIPTION
## Summary
- extract template editor state management into reusable `useTemplateEditor` hook
- move argument editing UI to new `TemplateArgumentsEditor` subcomponent
- simplify `TemplateEditor` by consuming hook and subcomponent

## Testing
- `npx eslint src/components/templates/TemplateEditor.tsx src/components/templates/TemplateArgumentsEditor.tsx src/hooks/useTemplateEditor.ts`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689b924ed69c8328b51765244ad305e0