### PR TITLE
refactor template editor into smaller components

### DIFF
--- a/src/components/templates/TemplateDetailsForm.tsx
+++ b/src/components/templates/TemplateDetailsForm.tsx
@@ -1,0 +1,65 @@
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+
+interface TemplateDetailsFormProps {
+  name: string;
+  description: string;
+  isPublic: boolean;
+  setName: (value: string) => void;
+  setDescription: (value: string) => void;
+  setIsPublic: (value: boolean) => void;
+}
+
+export default function TemplateDetailsForm({
+  name,
+  description,
+  isPublic,
+  setName,
+  setDescription,
+  setIsPublic,
+}: TemplateDetailsFormProps) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Template Details</CardTitle>
+        <CardDescription>
+          Configure your MCP prompt template metadata
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="space-y-2">
+          <Label htmlFor="name">Name *</Label>
+          <Input
+            id="name"
+            placeholder="Enter template name"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+          />
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="description">Description</Label>
+          <Textarea
+            id="description"
+            placeholder="Describe what this template does"
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            rows={3}
+          />
+        </div>
+
+        <div className="flex items-center space-x-2">
+          <Switch
+            id="public"
+            checked={isPublic}
+            onCheckedChange={setIsPublic}
+          />
+          <Label htmlFor="public">Make this template public</Label>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/templates/TemplateEditor.tsx
+++ b/src/components/templates/TemplateEditor.tsx
@@ -1,18 +1,15 @@
 import { useState } from 'react';
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Textarea } from "@/components/ui/textarea";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { Label } from "@/components/ui/label";
-import { Switch } from "@/components/ui/switch";
 import { useToast } from "@/hooks/use-toast";
 import useTemplateEditor from '@/hooks/useTemplateEditor';
 import { getUser } from "@/services/authService";
 import { saveTemplate } from "@/services/templateService";
-import { ArrowLeft, Save, Plus, Trash2 } from "lucide-react";
+import { ArrowLeft, Save, Trash2 } from "lucide-react";
 import { MCPTemplate, TemplateData } from '@/types/template';
 import DeleteConfirmDialog from './DeleteConfirmDialog';
 import TemplateArgumentsEditor from './TemplateArgumentsEditor';
+import TemplateDetailsForm from './TemplateDetailsForm';
+import TemplateMessagesEditor from './TemplateMessagesEditor';
 
 interface TemplateEditorProps {
   template?: MCPTemplate;
@@ -146,46 +143,14 @@ export default function TemplateEditor({ template, onSave, onCancel, onDelete }:
       </div>
 
       <div className="space-y-6">
-        {/* Template Details */}
-        <Card>
-          <CardHeader>
-            <CardTitle>Template Details</CardTitle>
-            <CardDescription>
-              Configure your MCP prompt template metadata
-            </CardDescription>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            <div className="space-y-2">
-              <Label htmlFor="name">Name *</Label>
-              <Input
-                id="name"
-                placeholder="Enter template name"
-                value={name}
-                onChange={(e) => setName(e.target.value)}
-              />
-            </div>
-            
-            <div className="space-y-2">
-              <Label htmlFor="description">Description</Label>
-              <Textarea
-                id="description"
-                placeholder="Describe what this template does"
-                value={description}
-                onChange={(e) => setDescription(e.target.value)}
-                rows={3}
-              />
-            </div>
-            
-            <div className="flex items-center space-x-2">
-              <Switch
-                id="public"
-                checked={isPublic}
-                onCheckedChange={setIsPublic}
-              />
-              <Label htmlFor="public">Make this template public</Label>
-            </div>
-          </CardContent>
-        </Card>
+        <TemplateDetailsForm
+          name={name}
+          description={description}
+          isPublic={isPublic}
+          setName={setName}
+          setDescription={setDescription}
+          setIsPublic={setIsPublic}
+        />
 
         <TemplateArgumentsEditor
           arguments_={arguments_}
@@ -194,55 +159,12 @@ export default function TemplateEditor({ template, onSave, onCancel, onDelete }:
           updateArgument={updateArgument}
         />
 
-        {/* Template Messages */}
-        <Card>
-          <CardHeader>
-            <div className="flex items-center justify-between">
-              <div>
-                <CardTitle>Messages</CardTitle>
-                <CardDescription>
-                  Define the conversation flow for your template
-                </CardDescription>
-              </div>
-              <Button onClick={addMessage} size="sm">
-                <Plus className="w-4 h-4 mr-2" />
-                Add Message
-              </Button>
-            </div>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            {messages.map((message, index) => (
-              <div key={index} className="space-y-4 p-4 border rounded-lg">
-                <div className="flex items-center justify-between">
-                  <div className="space-y-2 flex-1 mr-4">
-                    <Label>Role</Label>
-                    <select
-                      className="w-full px-3 py-2 border border-input bg-background rounded-md"
-                      value={message.role}
-                      onChange={(e) => updateMessage(index, 'role', e.target.value)}
-                    >
-                      <option value="user">User</option>
-                      <option value="assistant">Assistant</option>
-                      <option value="system">System</option>
-                    </select>
-                  </div>
-                  <Button variant="outline" size="sm" onClick={() => removeMessage(index)}>
-                    <Trash2 className="w-4 h-4" />
-                  </Button>
-                </div>
-                <div className="space-y-2">
-                  <Label>Content</Label>
-                  <Textarea
-                    placeholder="Enter message content. Use {{argumentName}} for variables."
-                    value={message.content}
-                    onChange={(e) => updateMessage(index, 'content', e.target.value)}
-                    rows={3}
-                  />
-                </div>
-              </div>
-            ))}
-          </CardContent>
-        </Card>
+        <TemplateMessagesEditor
+          messages={messages}
+          addMessage={addMessage}
+          removeMessage={removeMessage}
+          updateMessage={updateMessage}
+        />
       </div>
 
       {/* Actions */}

--- a/src/components/templates/TemplateMessagesEditor.tsx
+++ b/src/components/templates/TemplateMessagesEditor.tsx
@@ -1,0 +1,75 @@
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Plus, Trash2 } from "lucide-react";
+import { TemplateMessage } from '@/types/template';
+
+interface TemplateMessagesEditorProps {
+  messages: TemplateMessage[];
+  addMessage: () => void;
+  removeMessage: (index: number) => void;
+  updateMessage: (
+    index: number,
+    field: keyof TemplateMessage,
+    value: string
+  ) => void;
+}
+
+export default function TemplateMessagesEditor({
+  messages,
+  addMessage,
+  removeMessage,
+  updateMessage,
+}: TemplateMessagesEditorProps) {
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-center justify-between">
+          <div>
+            <CardTitle>Messages</CardTitle>
+            <CardDescription>
+              Define the conversation flow for your template
+            </CardDescription>
+          </div>
+          <Button onClick={addMessage} size="sm">
+            <Plus className="w-4 h-4 mr-2" />
+            Add Message
+          </Button>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {messages.map((message, index) => (
+          <div key={index} className="space-y-4 p-4 border rounded-lg">
+            <div className="flex items-center justify-between">
+              <div className="space-y-2 flex-1 mr-4">
+                <Label>Role</Label>
+                <select
+                  className="w-full px-3 py-2 border border-input bg-background rounded-md"
+                  value={message.role}
+                  onChange={(e) => updateMessage(index, 'role', e.target.value)}
+                >
+                  <option value="user">User</option>
+                  <option value="assistant">Assistant</option>
+                  <option value="system">System</option>
+                </select>
+              </div>
+              <Button variant="outline" size="sm" onClick={() => removeMessage(index)}>
+                <Trash2 className="w-4 h-4" />
+              </Button>
+            </div>
+            <div className="space-y-2">
+              <Label>Content</Label>
+              <Textarea
+                placeholder="Enter message content. Use {{argumentName}} for variables."
+                value={message.content}
+                onChange={(e) => updateMessage(index, 'content', e.target.value)}
+                rows={3}
+              />
+            </div>
+          </div>
+        ))}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/hooks/useArrayField.test.ts
+++ b/src/hooks/useArrayField.test.ts
@@ -1,0 +1,17 @@
+import { renderHook, act } from '@testing-library/react';
+import useArrayField from './useArrayField';
+
+describe('useArrayField', () => {
+  it('adds, updates, and removes items', () => {
+    const { result } = renderHook(() => useArrayField<{ value: string }>([], () => ({ value: '' })));
+
+    act(() => result.current.addItem());
+    expect(result.current.items).toHaveLength(1);
+
+    act(() => result.current.updateItem(0, 'value', 'test'));
+    expect(result.current.items[0].value).toBe('test');
+
+    act(() => result.current.removeItem(0));
+    expect(result.current.items).toHaveLength(0);
+  });
+});

--- a/src/hooks/useArrayField.ts
+++ b/src/hooks/useArrayField.ts
@@ -1,0 +1,21 @@
+import { useState } from 'react';
+
+export default function useArrayField<T>(initial: T[], createItem: () => T) {
+  const [items, setItems] = useState<T[]>(initial);
+
+  const addItem = () => {
+    setItems([...items, createItem()]);
+  };
+
+  const removeItem = (index: number) => {
+    setItems(items.filter((_, i) => i !== index));
+  };
+
+  const updateItem = <K extends keyof T>(index: number, field: K, value: T[K]) => {
+    const updated = [...items];
+    updated[index] = { ...updated[index], [field]: value };
+    setItems(updated);
+  };
+
+  return { items, addItem, removeItem, updateItem };
+}

--- a/src/hooks/useTemplateEditor.ts
+++ b/src/hooks/useTemplateEditor.ts
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { MCPTemplate, TemplateArgument, TemplateMessage, TemplateData } from '@/types/template';
+import useArrayField from './useArrayField';
 
 export function useTemplateEditor(initial?: MCPTemplate) {
   const [name, setName] = useState(initial?.name ?? '');
@@ -7,48 +8,26 @@ export function useTemplateEditor(initial?: MCPTemplate) {
   const [isPublic, setIsPublic] = useState(initial?.is_public ?? false);
 
   const initialData: TemplateData = (initial?.template_data ?? {}) as TemplateData;
-  const [arguments_, setArguments] = useState<TemplateArgument[]>(
-    initialData.arguments ?? []
+
+  const {
+    items: arguments_,
+    addItem: addArgument,
+    removeItem: removeArgument,
+    updateItem: updateArgument,
+  } = useArrayField<TemplateArgument>(
+    initialData.arguments ?? [],
+    () => ({ name: '', description: '', required: false })
   );
-  const [messages, setMessages] = useState<TemplateMessage[]>(
-    initialData.messages ?? [{ role: 'user', content: '{{prompt}}' }]
+
+  const {
+    items: messages,
+    addItem: addMessage,
+    removeItem: removeMessage,
+    updateItem: updateMessage,
+  } = useArrayField<TemplateMessage>(
+    initialData.messages ?? [{ role: 'user', content: '{{prompt}}' }],
+    () => ({ role: 'user', content: '' })
   );
-
-  const addArgument = () => {
-    setArguments([...arguments_, { name: '', description: '', required: false }]);
-  };
-
-  const removeArgument = (index: number) => {
-    setArguments(arguments_.filter((_, i) => i !== index));
-  };
-
-  const updateArgument = (
-    index: number,
-    field: keyof TemplateArgument,
-    value: string | boolean
-  ) => {
-    const updated = [...arguments_];
-    updated[index] = { ...updated[index], [field]: value };
-    setArguments(updated);
-  };
-
-  const addMessage = () => {
-    setMessages([...messages, { role: 'user', content: '' }]);
-  };
-
-  const removeMessage = (index: number) => {
-    setMessages(messages.filter((_, i) => i !== index));
-  };
-
-  const updateMessage = (
-    index: number,
-    field: keyof TemplateMessage,
-    value: string
-  ) => {
-    const updated = [...messages];
-    updated[index] = { ...updated[index], [field]: value };
-    setMessages(updated);
-  };
 
   return {
     name,


### PR DESCRIPTION
## Summary
- extract reusable `useArrayField` hook with unit tests
- refactor template editor state management to use the array hook
- split `TemplateEditor` into `TemplateDetailsForm` and `TemplateMessagesEditor` for clarity

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689baecd39b083289133f070c2dc8477