### PR TITLE
chore: standardize Supabase env vars with VITE prefix

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,2 @@
-SUPABASE_URL=https://your-supabase-url
-SUPABASE_PUBLISHABLE_KEY=your-publishable-key
+VITE_SUPABASE_URL=https://your-supabase-url
+VITE_SUPABASE_ANON_KEY=your-anon-key

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ npm run preview
 ```
 
 ### Environment Variables
-Create a `.env.local` file based on `.env.example` and provide your Supabase credentials:
+Create a `.env.local` file based on `.env.example` and provide your Supabase URL and anonymous key:
 ```sh
 VITE_SUPABASE_URL=https://fdtotoxhicqhoulckkgj.supabase.co
 VITE_SUPABASE_ANON_KEY=<your-supabase-anon-key>

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -1,6 +1,6 @@
 # Development Tasks Plan
 
-1. [ ] Standardize environment variables
+1. [x] Standardize environment variables
    - Rename keys in `.env.example` and code to use consistent `VITE_` prefix
    - Update documentation and references
 2. [ ] Strengthen TypeScript configuration

--- a/src/integrations/supabase/client.ts
+++ b/src/integrations/supabase/client.ts
@@ -3,16 +3,16 @@ import { createClient } from '@supabase/supabase-js';
 import type { Database } from './types';
 
 const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL as string | undefined;
-const SUPABASE_PUBLISHABLE_KEY = import.meta.env.VITE_SUPABASE_ANON_KEY as string | undefined;
+const SUPABASE_ANON_KEY = import.meta.env.VITE_SUPABASE_ANON_KEY as string | undefined;
 
-if (!SUPABASE_URL || !SUPABASE_PUBLISHABLE_KEY) {
+if (!SUPABASE_URL || !SUPABASE_ANON_KEY) {
   throw new Error('Missing Supabase environment variables: VITE_SUPABASE_URL and VITE_SUPABASE_ANON_KEY must be defined');
 }
 
 // Import the supabase client like this:
 // import { supabase } from "@/integrations/supabase/client";
 
-export const supabase = createClient<Database>(SUPABASE_URL, SUPABASE_PUBLISHABLE_KEY, {
+export const supabase = createClient<Database>(SUPABASE_URL, SUPABASE_ANON_KEY, {
   auth: {
     storage: localStorage,
     persistSession: true,


### PR DESCRIPTION
## Summary
- rename Supabase environment variables to use VITE_ prefix
- align Supabase client with new variable names
- update docs and project plan

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aea829f2e48328833b151dbe29fc4b