### PR TITLE
Add tests for TemplateService findByTags

### DIFF
--- a/docs/plan.md
+++ b/docs/plan.md
@@ -22,7 +22,7 @@
    - Separate create and update validation into distinct functions
 8. [ ] Remove legacy `TemplateData` interface
    - Delete interface and update related code and types
-9. [ ] Add tests for `findByTags`
+9. [x] Add tests for `findByTags`
    - Verify correct filtering and error handling
 10. [ ] Replace `console.error` with structured logging
    - Implement configurable logging utility

--- a/src/services/templateService.test.ts
+++ b/src/services/templateService.test.ts
@@ -320,4 +320,48 @@ describe('TemplateService', () => {
         .rejects.toThrow('Failed to delete template: Delete failed');
     });
   });
+
+  describe('findByTags', () => {
+    it('should return templates matching tags', async () => {
+      const mockData = [{
+        id: '1',
+        name: 'Tagged Template',
+        description: 'Desc',
+        template_data: {
+          messages: [{ role: 'user', content: 'Hello' }],
+          arguments: []
+        },
+        user_id: 'user-1',
+        is_public: false,
+        created_at: '2024-01-01T00:00:00Z',
+        updated_at: '2024-01-01T00:00:00Z',
+        tags: ['write-unit-test']
+      }];
+
+      mockSupabase.from.mockReturnValue({
+        select: vi.fn().mockReturnValue({
+          overlaps: vi.fn().mockResolvedValue({ data: mockData, error: null })
+        })
+      });
+
+      const result = await service.findByTags(['write-unit-test']);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].tags).toEqual(['write-unit-test']);
+    });
+
+    it('should handle supabase errors in findByTags', async () => {
+      mockSupabase.from.mockReturnValue({
+        select: vi.fn().mockReturnValue({
+          overlaps: vi.fn().mockResolvedValue({
+            data: null,
+            error: { message: 'Search failed' }
+          })
+        })
+      });
+
+      await expect(service.findByTags(['write-unit-test']))
+        .rejects.toThrow('Failed to search templates by tags: Search failed');
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- add unit tests for TemplateService.findByTags to verify tag filtering and error handling
- mark plan item for findByTags tests as complete

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b221488e5c8328b81542181750722c