### PR TITLE
feat: centralize timestamps and add logging utility

### DIFF
--- a/docs/plan.md
+++ b/docs/plan.md
@@ -15,16 +15,16 @@
 5. [ ] Refactor `AuthForm` component
    - Split into `SignInForm`, `SignUpForm`, and `PasswordResetForm`
    - Extract repeated toast and state management logic
-6. [ ] Centralize timestamp generation in `TemplateService`
+6. [x] Centralize timestamp generation in `TemplateService`
    - Create utility for generating `created_at` and `updated_at`
    - Remove duplicated `new Date().toISOString()` calls
-7. [ ] Simplify `validateTemplate`
+7. [x] Simplify `validateTemplate`
    - Separate create and update validation into distinct functions
-8. [ ] Remove legacy `TemplateData` interface
+8. [x] Remove legacy `TemplateData` interface
    - Delete interface and update related code and types
 9. [x] Add tests for `findByTags`
    - Verify correct filtering and error handling
-10. [ ] Replace `console.error` with structured logging
+10. [x] Replace `console.error` with structured logging
    - Implement configurable logging utility
    - Replace `console.error` usages in services and pages
 

--- a/src/api/supabaseApi.ts
+++ b/src/api/supabaseApi.ts
@@ -1,4 +1,5 @@
 import { toast } from '@/hooks/use-toast';
+import { logger } from '@/lib/logger';
 
 // Type for Supabase errors
 interface SupabaseError {
@@ -16,12 +17,12 @@ export async function handleRequest<T, E extends { message: string } = SupabaseE
   try {
     const { data, error } = await request;
     if (error) {
-      console.error(error);
+      logger.error(error);
       toast({ variant: 'destructive', title: 'Error', description: errorMessage });
     }
     return { data: data ?? null, error };
   } catch (error: unknown) {
-    console.error(error);
+    logger.error(error);
     toast({ variant: 'destructive', title: 'Error', description: errorMessage });
     return {
       data: null,

--- a/src/components/ErrorBoundary.test.tsx
+++ b/src/components/ErrorBoundary.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import { expect, test, vi } from 'vitest';
 import { ErrorBoundary } from './ErrorBoundary';
+import { logger } from '@/lib/logger';
 
 // Component that throws an error when shouldThrow is true
 function ThrowError({ shouldThrow }: { shouldThrow: boolean }) {
@@ -21,7 +22,8 @@ test('shouldRenderChildrenWhenNoError', () => {
 });
 
 test('shouldRenderErrorUIWhenChildThrowsError', () => {
-  // Suppress console.error for this test
+  // Suppress logger.error and console.error for this test
+  const loggerSpy = vi.spyOn(logger, 'error').mockImplementation(() => {});
   const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
   render(
@@ -34,10 +36,12 @@ test('shouldRenderErrorUIWhenChildThrowsError', () => {
   expect(screen.getByText("We're sorry, but something unexpected happened.")).toBeInTheDocument();
   expect(screen.getByRole('button', { name: /reload page/i })).toBeInTheDocument();
 
+  loggerSpy.mockRestore();
   consoleSpy.mockRestore();
 });
 
 test('shouldLogErrorWhenCaught', () => {
+  const loggerSpy = vi.spyOn(logger, 'error').mockImplementation(() => {});
   const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
   render(
@@ -46,11 +50,12 @@ test('shouldLogErrorWhenCaught', () => {
     </ErrorBoundary>
   );
 
-  expect(consoleSpy).toHaveBeenCalledWith(
+  expect(loggerSpy).toHaveBeenCalledWith(
     'Error caught by boundary:',
     expect.any(Error),
     expect.any(Object)
   );
 
+  loggerSpy.mockRestore();
   consoleSpy.mockRestore();
 });

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { AlertTriangle } from 'lucide-react';
 import { Button } from './ui/button';
+import { logger } from '@/lib/logger';
 
 interface ErrorBoundaryState {
   hasError: boolean;
@@ -25,7 +26,7 @@ export class ErrorBoundary extends React.Component<
   }
 
   componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
-    console.error('Error caught by boundary:', error, errorInfo);
+    logger.error('Error caught by boundary:', error, errorInfo);
   }
 
   render() {

--- a/src/lib/logger.test.ts
+++ b/src/lib/logger.test.ts
@@ -1,0 +1,11 @@
+import { describe, it, expect, vi } from 'vitest';
+import { logger } from './logger';
+
+describe('logger', () => {
+  it('logs errors using console.error', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    logger.error('test');
+    expect(spy).toHaveBeenCalledWith('test');
+    spy.mockRestore();
+  });
+});

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -1,0 +1,14 @@
+const levels = ['debug', 'info', 'warn', 'error'] as const;
+type LogLevel = typeof levels[number];
+const envLevel = (import.meta.env?.VITE_LOG_LEVEL as LogLevel) || 'info';
+
+function shouldLog(level: LogLevel) {
+  return levels.indexOf(level) >= levels.indexOf(envLevel);
+}
+
+export const logger = {
+  debug: (...args: unknown[]) => { if (shouldLog('debug')) console.debug(...args); },
+  info: (...args: unknown[]) => { if (shouldLog('info')) console.info(...args); },
+  warn: (...args: unknown[]) => { if (shouldLog('warn')) console.warn(...args); },
+  error: (...args: unknown[]) => { if (shouldLog('error')) console.error(...args); }
+};

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { cn } from './utils';
+import { cn, generateTimestamps } from './utils';
 
 describe('cn utility function', () => {
   it('joins class names correctly', () => {
@@ -12,5 +12,13 @@ describe('cn utility function', () => {
 
   it('returns empty string when no inputs are provided', () => {
     expect(cn()).toBe('');
+  });
+});
+
+describe('generateTimestamps', () => {
+  it('returns matching ISO timestamps', () => {
+    const { created_at, updated_at } = generateTimestamps();
+    expect(created_at).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    expect(updated_at).toBe(created_at);
   });
 });

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -22,3 +22,8 @@ export function formatDetailedDate(dateString: string) {
     minute: '2-digit'
   });
 }
+
+export function generateTimestamps() {
+  const now = new Date().toISOString();
+  return { created_at: now, updated_at: now };
+}

--- a/src/pages/Index.test.tsx
+++ b/src/pages/Index.test.tsx
@@ -3,6 +3,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { BrowserRouter } from 'react-router-dom';
 import Index from './Index';
 import { getSession, onAuthStateChange, signOut } from '@/services/authService';
+import { logger } from '@/lib/logger';
 
 vi.mock('@/services/authService', () => ({
   getSession: vi.fn(),
@@ -411,8 +412,8 @@ describe('Index', () => {
     // Mock getSession to throw error (lines 30-34)
     mockGetSession.mockRejectedValue(new Error('Auth service unavailable'));
 
-    // Mock console.error to verify error logging
-    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    // Mock logger.error to verify error logging
+    const loggerSpy = vi.spyOn(logger, 'error').mockImplementation(() => {});
 
     render(
       <IndexWrapper>
@@ -422,7 +423,7 @@ describe('Index', () => {
 
     // Should log auth initialization error and still set loading to false
     await waitFor(() => {
-      expect(consoleSpy).toHaveBeenCalledWith(
+      expect(loggerSpy).toHaveBeenCalledWith(
         'Auth initialization error:',
         expect.any(Error)
       );
@@ -433,7 +434,7 @@ describe('Index', () => {
       expect(screen.getByTestId('auth-form')).toBeInTheDocument();
     });
 
-    consoleSpy.mockRestore();
+    loggerSpy.mockRestore();
   });
 
   it('handles auth success callback correctly', async () => {
@@ -464,8 +465,8 @@ describe('Index', () => {
       error: { message: 'Invalid refresh token', code: '401' }
     });
 
-    // Mock console.error to verify error logging
-    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    // Mock logger.error to verify error logging
+    const loggerSpy = vi.spyOn(logger, 'error').mockImplementation(() => {});
 
     render(
       <IndexWrapper>
@@ -475,7 +476,7 @@ describe('Index', () => {
 
     // Should log the supabase error and handle gracefully
     await waitFor(() => {
-      expect(consoleSpy).toHaveBeenCalledWith(
+      expect(loggerSpy).toHaveBeenCalledWith(
         'Auth initialization error:',
         expect.objectContaining({ message: 'Invalid refresh token' })
       );
@@ -486,6 +487,6 @@ describe('Index', () => {
       expect(screen.getByTestId('auth-form')).toBeInTheDocument();
     });
 
-    consoleSpy.mockRestore();
+    loggerSpy.mockRestore();
   });
 });

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -5,6 +5,7 @@ import AuthForm from "@/components/auth/AuthForm";
 // Lazy load Dashboard to reduce initial bundle size
 const Dashboard = lazy(() => import("@/pages/Dashboard"));
 import PasswordChangeForm from "@/components/auth/PasswordChangeForm";
+import { logger } from '@/lib/logger';
 
 const Index = () => {
   const [user, setUser] = useState<User | null>(null);
@@ -29,7 +30,7 @@ const Index = () => {
           setLoading(false);
         }
       } catch (error) {
-        console.error('Auth initialization error:', error);
+        logger.error('Auth initialization error:', error);
         if (isMounted) {
           setLoading(false);
         }

--- a/src/pages/NotFound.test.tsx
+++ b/src/pages/NotFound.test.tsx
@@ -2,13 +2,14 @@ import { render, screen } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { BrowserRouter, MemoryRouter } from 'react-router-dom';
 import NotFound from './NotFound';
+import { logger } from '@/lib/logger';
 
-// Mock console.error to test error logging
-const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+// Mock logger.error to test error logging
+const loggerSpy = vi.spyOn(logger, 'error').mockImplementation(() => {});
 
 describe('NotFound', () => {
   beforeEach(() => {
-    consoleSpy.mockClear();
+    loggerSpy.mockClear();
   });
 
   it('renders 404 error page with correct content', () => {
@@ -43,7 +44,7 @@ describe('NotFound', () => {
       </MemoryRouter>
     );
     
-    expect(consoleSpy).toHaveBeenCalledWith(
+    expect(loggerSpy).toHaveBeenCalledWith(
       '404 Error: User attempted to access non-existent route:',
       testPath
     );
@@ -58,7 +59,7 @@ describe('NotFound', () => {
       </MemoryRouter>
     );
     
-    expect(consoleSpy).toHaveBeenCalledWith(
+    expect(loggerSpy).toHaveBeenCalledWith(
       '404 Error: User attempted to access non-existent route:',
       testPath
     );
@@ -89,12 +90,12 @@ describe('NotFound', () => {
       </MemoryRouter>
     );
     
-    expect(consoleSpy).toHaveBeenCalledWith(
+    expect(loggerSpy).toHaveBeenCalledWith(
       '404 Error: User attempted to access non-existent route:',
       '/first-path'
     );
-    
-    consoleSpy.mockClear();
+
+    loggerSpy.mockClear();
     
     // Second render with different path
     render(
@@ -103,7 +104,7 @@ describe('NotFound', () => {
       </MemoryRouter>
     );
     
-    expect(consoleSpy).toHaveBeenCalledWith(
+    expect(loggerSpy).toHaveBeenCalledWith(
       '404 Error: User attempted to access non-existent route:',
       '/second-path'
     );

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -1,11 +1,12 @@
 import { useLocation } from "react-router-dom";
 import { useEffect } from "react";
+import { logger } from '@/lib/logger';
 
 const NotFound = () => {
   const location = useLocation();
 
   useEffect(() => {
-    console.error(
+    logger.error(
       "404 Error: User attempted to access non-existent route:",
       location.pathname
     );

--- a/src/services/templateService.ts
+++ b/src/services/templateService.ts
@@ -1,5 +1,6 @@
 import { SupabaseClient } from '@supabase/supabase-js';
-import { Template, validateTemplate } from '../types/template';
+import { Template, validateNewTemplate, validateTemplateUpdate } from '../types/template';
+import { generateTimestamps } from '@/lib/utils';
 import { TaskTag } from '../types/tags';
 
 // Database row type for template data
@@ -37,10 +38,12 @@ export class TemplateService {
 
   async create(templateData: Omit<Template, 'id' | 'createdAt' | 'updatedAt'>): Promise<Template> {
     // Validate first
-    const errors = validateTemplate(templateData);
+    const errors = validateNewTemplate(templateData);
     if (errors.length > 0) {
       throw new Error(errors.join(', '));
     }
+
+    const { created_at, updated_at } = generateTimestamps();
 
     const payload = {
       name: templateData.name,
@@ -52,8 +55,8 @@ export class TemplateService {
       user_id: templateData.userId,
       is_public: templateData.isPublic,
       tags: templateData.tags || null,
-      created_at: new Date().toISOString(),
-      updated_at: new Date().toISOString()
+      created_at,
+      updated_at
       // Note: created_by_username will be automatically populated by database trigger
     };
 
@@ -109,13 +112,14 @@ export class TemplateService {
 
   async update(id: string, updates: Partial<Template>): Promise<Template> {
     // Validate updates
-    const errors = validateTemplate(updates, true);
+    const errors = validateTemplateUpdate(updates);
     if (errors.length > 0) {
       throw new Error(errors.join(', '));
     }
 
+    const { updated_at } = generateTimestamps();
     const payload: TemplateUpdatePayload = {
-      updated_at: new Date().toISOString()
+      updated_at
     };
 
     // Only include fields that are being updated

--- a/src/types/template.test.ts
+++ b/src/types/template.test.ts
@@ -1,80 +1,66 @@
 import { describe, it, expect, expectTypeOf } from 'vitest';
-import { TemplateData, TemplateArgument, TemplateMessage, MCPTemplate, Template, validateTemplate } from './template';
+import { TemplateArgument, TemplateMessage, MCPTemplate, Template, validateNewTemplate, validateTemplateUpdate } from './template';
 
 describe('Template validation', () => {
-  describe('validateTemplate', () => {
-    describe('create validation (isUpdate=false)', () => {
-      it('should validate required fields', () => {
-        expect(validateTemplate({})).toContain('Name is required');
-      });
-      
-      it('should validate name length', () => {
-        expect(validateTemplate({ name: 'a'.repeat(101) }))
-          .toContain('Name cannot exceed 100 characters');
-      });
-
-      it('should require at least one message', () => {
-        expect(validateTemplate({ name: 'Valid Name', messages: [] }))
-          .toContain('At least one message is required');
-      });
-
-      it('should return empty array for valid template', () => {
-        const validTemplate: Partial<Template> = {
-          name: 'Valid Template',
-          messages: [{ role: 'user', content: 'Hello' }]
-        };
-        expect(validateTemplate(validTemplate)).toEqual([]);
-      });
-
-      it('should trim whitespace for name validation', () => {
-        expect(validateTemplate({ name: '   ' })).toContain('Name is required');
-      });
-
-      it('should return multiple errors for multiple issues', () => {
-        const invalidTemplate: Partial<Template> = {
-          name: '',
-          messages: []
-        };
-        const errors = validateTemplate(invalidTemplate);
-        expect(errors).toContain('Name is required');
-        expect(errors).toContain('At least one message is required');
-        expect(errors).toHaveLength(2);
-      });
+  describe('validateNewTemplate', () => {
+    it('should validate required fields', () => {
+      expect(validateNewTemplate({})).toContain('Name is required');
     });
 
-    describe('update validation (isUpdate=true)', () => {
-      it('should allow partial updates without required fields', () => {
-        const partialUpdate = { description: 'New description' };
-        expect(validateTemplate(partialUpdate, true)).toEqual([]);
-      });
+    it('should validate name length', () => {
+      expect(validateNewTemplate({ name: 'a'.repeat(101) }))
+        .toContain('Name cannot exceed 100 characters');
+    });
 
-      it('should validate name if provided in update', () => {
-        const invalidUpdate = { name: '' };
-        expect(validateTemplate(invalidUpdate, true)).toContain('Name is required');
-      });
+    it('should require at least one message', () => {
+      expect(validateNewTemplate({ name: 'Valid Name', messages: [] }))
+        .toContain('At least one message is required');
+    });
 
-      it('should validate messages if provided in update', () => {
-        const invalidUpdate = { messages: [] };
-        expect(validateTemplate(invalidUpdate, true)).toContain('At least one message is required');
-      });
+    it('should return empty array for valid template', () => {
+      const validTemplate: Partial<Template> = {
+        name: 'Valid Template',
+        messages: [{ role: 'user', content: 'Hello' }]
+      };
+      expect(validateNewTemplate(validTemplate)).toEqual([]);
+    });
 
-      it('should accept valid partial updates', () => {
-        const validUpdate = { name: 'Updated Name' };
-        expect(validateTemplate(validUpdate, true)).toEqual([]);
-      });
+    it('should trim whitespace for name validation', () => {
+      expect(validateNewTemplate({ name: '   ' })).toContain('Name is required');
+    });
+
+    it('should return multiple errors for multiple issues', () => {
+      const invalidTemplate: Partial<Template> = {
+        name: '',
+        messages: []
+      };
+      const errors = validateNewTemplate(invalidTemplate);
+      expect(errors).toContain('Name is required');
+      expect(errors).toContain('At least one message is required');
+      expect(errors).toHaveLength(2);
     });
   });
-});
 
-// Legacy type tests - to be removed after migration
-describe('TemplateData type', () => {
-  it('has arguments and messages arrays', () => {
-    expectTypeOf<TemplateData>().toHaveProperty('arguments').toEqualTypeOf<TemplateArgument[] | undefined>();
-    expectTypeOf<TemplateData>().toHaveProperty('messages').toEqualTypeOf<TemplateMessage[] | undefined>();
-  });
+  describe('validateTemplateUpdate', () => {
+    it('should allow partial updates without required fields', () => {
+      const partialUpdate = { description: 'New description' };
+      expect(validateTemplateUpdate(partialUpdate)).toEqual([]);
+    });
 
-  it('is used in MCPTemplate', () => {
-    expectTypeOf<MCPTemplate>().toHaveProperty('template_data').toEqualTypeOf<TemplateData | null>();
+    it('should validate name if provided in update', () => {
+      const invalidUpdate = { name: '' };
+      expect(validateTemplateUpdate(invalidUpdate)).toContain('Name is required');
+    });
+
+    it('should validate messages if provided in update', () => {
+      const invalidUpdate = { messages: [] };
+      expect(validateTemplateUpdate(invalidUpdate)).toContain('At least one message is required');
+    });
+
+    it('should accept valid partial updates', () => {
+      const validUpdate = { name: 'Updated Name' };
+      expect(validateTemplateUpdate(validUpdate)).toEqual([]);
+    });
   });
 });
 
@@ -90,5 +76,14 @@ describe('Template interface', () => {
     expectTypeOf<Template>().toHaveProperty('userId').toEqualTypeOf<string>();
     expectTypeOf<Template>().toHaveProperty('createdAt').toEqualTypeOf<string>();
     expectTypeOf<Template>().toHaveProperty('updatedAt').toEqualTypeOf<string>();
+  });
+});
+
+describe('MCPTemplate type', () => {
+  it('has template_data with messages and arguments', () => {
+    expectTypeOf<MCPTemplate>().toHaveProperty('template_data').toEqualTypeOf<{
+      messages: TemplateMessage[];
+      arguments: TemplateArgument[];
+    } | null>();
   });
 });

--- a/src/types/template.ts
+++ b/src/types/template.ts
@@ -26,17 +26,14 @@ export interface Template {
   tags?: TaskTag[];
 }
 
-// Legacy interface for database mapping - will be removed in next phase
-export interface TemplateData {
-  arguments?: TemplateArgument[];
-  messages?: TemplateMessage[];
-}
-
 export interface MCPTemplate {
   id: string;
   name: string;
   description: string | null;
-  template_data: TemplateData | null;
+  template_data: {
+    messages: TemplateMessage[];
+    arguments: TemplateArgument[];
+  } | null;
   is_public: boolean;
   created_at: string;
   updated_at: string;
@@ -45,50 +42,52 @@ export interface MCPTemplate {
 }
 
 // Simple validation function
-export function validateTemplate(template: Partial<Template>, isUpdate = false): string[] {
+export function validateNewTemplate(template: Partial<Template>): string[] {
   const errors: string[] = [];
-  
-  if (isUpdate) {
-    // For updates, only validate fields that are being set
-    if ('name' in template) {
-      if (!template.name?.trim()) {
-        errors.push('Name is required');
-      }
-      
-      if (template.name && template.name.length > 100) {
-        errors.push('Name cannot exceed 100 characters');
-      }
-    }
-    
-    if ('messages' in template) {
-      if (!template.messages || template.messages.length === 0) {
-        errors.push('At least one message is required');
-      }
-    }
-    
-    if ('tags' in template) {
-      if (template.tags && template.tags.length > 5) {
-        errors.push('Maximum 5 tags allowed per template');
-      }
-    }
-  } else {
-    // For create operations, validate all required fields
+
+  if (!template.name?.trim()) {
+    errors.push('Name is required');
+  }
+
+  if (template.name && template.name.length > 100) {
+    errors.push('Name cannot exceed 100 characters');
+  }
+
+  if (!template.messages || template.messages.length === 0) {
+    errors.push('At least one message is required');
+  }
+
+  if (template.tags && template.tags.length > 5) {
+    errors.push('Maximum 5 tags allowed per template');
+  }
+
+  return errors;
+}
+
+export function validateTemplateUpdate(template: Partial<Template>): string[] {
+  const errors: string[] = [];
+
+  if ('name' in template) {
     if (!template.name?.trim()) {
       errors.push('Name is required');
     }
-    
+
     if (template.name && template.name.length > 100) {
       errors.push('Name cannot exceed 100 characters');
     }
-    
+  }
+
+  if ('messages' in template) {
     if (!template.messages || template.messages.length === 0) {
       errors.push('At least one message is required');
     }
-    
+  }
+
+  if ('tags' in template) {
     if (template.tags && template.tags.length > 5) {
       errors.push('Maximum 5 tags allowed per template');
     }
   }
-  
+
   return errors;
 }


### PR DESCRIPTION
## Summary
- add generateTimestamps helper and use in TemplateService
- split template validation into create/update functions and drop TemplateData
- introduce configurable logger and replace console.error usages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b2361c76708328b34ce74c7058e078