### PR TITLE
Refactor auth form into modular components

### DIFF
--- a/docs/plan.md
+++ b/docs/plan.md
@@ -12,7 +12,7 @@
 4. [x] Introduce secure session storage
    - Migrate Supabase token storage from `localStorage` to HTTP-only cookies or similar
    - Update Supabase client and adjust affected tests
-5. [ ] Refactor `AuthForm` component
+5. [x] Refactor `AuthForm` component
    - Split into `SignInForm`, `SignUpForm`, and `PasswordResetForm`
    - Extract repeated toast and state management logic
 6. [x] Centralize timestamp generation in `TemplateService`

--- a/src/components/auth/AuthForm.tsx
+++ b/src/components/auth/AuthForm.tsx
@@ -1,183 +1,16 @@
 import React, { useState } from 'react';
-import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { Label } from "@/components/ui/label";
-import { useToast } from "@/hooks/use-toast";
-import { signUp, signIn, resetPassword } from "@/services/authService";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import SignInForm from './SignInForm';
+import SignUpForm from './SignUpForm';
+import PasswordResetForm from './PasswordResetForm';
 
 interface AuthFormProps {
   onAuthSuccess: () => void;
 }
 
 export default function AuthForm({ onAuthSuccess }: AuthFormProps) {
-  const [email, setEmail] = useState('');
-  const [username, setUsername] = useState('');
-  const [password, setPassword] = useState('');
-  const [loading, setLoading] = useState(false);
-  const [resetEmail, setResetEmail] = useState('');
   const [showResetForm, setShowResetForm] = useState(false);
-  const [usernameAvailable, setUsernameAvailable] = useState<boolean | null>(null);
-  const [checkingUsername, setCheckingUsername] = useState(false);
-  const { toast } = useToast();
-
-  // Check username availability with debouncing
-  const checkUsernameAvailability = async (usernameToCheck: string) => {
-    if (usernameToCheck.length < 3) {
-      setUsernameAvailable(null);
-      return;
-    }
-
-    setCheckingUsername(true);
-    try {
-      // Import UserProfileService dynamically to avoid circular dependencies
-      const { UserProfileService } = await import('@/services/userProfileService');
-      const { data: isAvailable } = await UserProfileService.isUsernameAvailable(usernameToCheck);
-      setUsernameAvailable(isAvailable);
-    } catch {
-      setUsernameAvailable(null);
-    } finally {
-      setCheckingUsername(false);
-    }
-  };
-
-  // Debounced username check
-  React.useEffect(() => {
-    const timeoutId = setTimeout(() => {
-      if (username.trim()) {
-        checkUsernameAvailability(username.trim());
-      } else {
-        setUsernameAvailable(null);
-      }
-    }, 500);
-
-    return () => clearTimeout(timeoutId);
-  }, [username]);
-
-  const handleSignUp = async (e: React.FormEvent) => {
-    e.preventDefault();
-    
-    // Validate username
-    if (!username.trim()) {
-      toast({
-        variant: "destructive",
-        title: "Username required",
-        description: "Please enter a username"
-      });
-      return;
-    }
-
-    if (username.trim().length < 3) {
-      toast({
-        variant: "destructive",
-        title: "Username too short",
-        description: "Username must be at least 3 characters long"
-      });
-      return;
-    }
-
-    if (usernameAvailable === false) {
-      toast({
-        variant: "destructive",
-        title: "Username unavailable",
-        description: "Please choose a different username"
-      });
-      return;
-    }
-
-    setLoading(true);
-
-    try {
-      const redirectUrl = `${window.location.origin}/`;
-      
-      const { error } = await signUp(email, password, username.trim(), redirectUrl);
-
-      if (error) {
-        toast({
-          variant: "destructive",
-          title: "Sign up failed",
-          description: error.message
-        });
-      } else {
-        toast({
-          title: "Check your email",
-          description: "We've sent you a confirmation link to complete your registration."
-        });
-        // Reset form
-        setEmail('');
-        setUsername('');
-        setPassword('');
-      }
-    } catch {
-      toast({
-        variant: "destructive",
-        title: "Error",
-        description: "An unexpected error occurred"
-      });
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  const handleSignIn = async (e: React.FormEvent) => {
-    e.preventDefault();
-    setLoading(true);
-
-    try {
-      const { error } = await signIn(email, password);
-
-      if (error) {
-        toast({
-          variant: "destructive",
-          title: "Sign in failed",
-          description: error.message
-        });
-      } else {
-        onAuthSuccess();
-      }
-      } catch {
-      toast({
-        variant: "destructive",
-        title: "Error",
-        description: "An unexpected error occurred"
-      });
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  const handleResetPassword = async (e: React.FormEvent) => {
-    e.preventDefault();
-    setLoading(true);
-
-    try {
-      const { error } = await resetPassword(resetEmail, `${window.location.origin}/`);
-
-      if (error) {
-        toast({
-          variant: "destructive",
-          title: "Reset failed",
-          description: error.message
-        });
-      } else {
-        toast({
-          title: "Reset email sent",
-          description: "Check your email for password reset instructions."
-        });
-        setShowResetForm(false);
-        setResetEmail('');
-      }
-      } catch {
-      toast({
-        variant: "destructive",
-        title: "Error",
-        description: "An unexpected error occurred"
-      });
-    } finally {
-      setLoading(false);
-    }
-  };
 
   return (
     <div className="min-h-screen flex items-center justify-center p-4">
@@ -190,142 +23,26 @@ export default function AuthForm({ onAuthSuccess }: AuthFormProps) {
         </CardHeader>
         <CardContent>
           <Tabs defaultValue="signin" className="w-full">
-            <TabsList className="grid w-full grid-cols-2">
-              <TabsTrigger value="signin">Sign In</TabsTrigger>
-              <TabsTrigger value="signup">Sign Up</TabsTrigger>
-            </TabsList>
-            
-            <TabsContent value="signin">
-              {!showResetForm ? (
-                <form onSubmit={handleSignIn} className="space-y-4">
-                  <div className="space-y-2">
-                    <Label htmlFor="signin-email">Email</Label>
-                    <Input
-                      id="signin-email"
-                      type="email"
-                      placeholder="Enter your email"
-                      value={email}
-                      onChange={(e) => setEmail(e.target.value)}
-                      required
-                    />
-                  </div>
-                  <div className="space-y-2">
-                    <Label htmlFor="signin-password">Password</Label>
-                    <Input
-                      id="signin-password"
-                      type="password"
-                      placeholder="Enter your password"
-                      value={password}
-                      onChange={(e) => setPassword(e.target.value)}
-                      required
-                    />
-                  </div>
-                  <Button type="submit" className="w-full" disabled={loading}>
-                    {loading ? "Signing in..." : "Sign In"}
-                  </Button>
-                  <div className="text-center">
-                    <Button 
-                      type="button"
-                      variant="link" 
-                      className="text-sm text-muted-foreground"
-                      onClick={() => setShowResetForm(true)}
-                    >
-                      Forgot your password?
-                    </Button>
-                  </div>
-                </form>
-              ) : (
-                <form onSubmit={handleResetPassword} className="space-y-4">
-                  <div className="space-y-2">
-                    <Label htmlFor="reset-email">Email</Label>
-                    <Input
-                      id="reset-email"
-                      type="email"
-                      placeholder="Enter your email"
-                      value={resetEmail}
-                      onChange={(e) => setResetEmail(e.target.value)}
-                      required
-                    />
-                  </div>
-                  <Button type="submit" className="w-full" disabled={loading}>
-                    {loading ? "Sending reset email..." : "Send Reset Email"}
-                  </Button>
-                  <div className="text-center">
-                    <Button 
-                      type="button"
-                      variant="link" 
-                      className="text-sm text-muted-foreground"
-                      onClick={() => {
-                        setShowResetForm(false);
-                        setResetEmail('');
-                      }}
-                    >
-                      Back to sign in
-                    </Button>
-                  </div>
-                </form>
-              )}
-            </TabsContent>
-            
-            <TabsContent value="signup">
-              <form onSubmit={handleSignUp} className="space-y-4">
-                <div className="space-y-2">
-                  <Label htmlFor="signup-email">Email</Label>
-                  <Input
-                    id="signup-email"
-                    type="email"
-                    placeholder="Enter your email"
-                    value={email}
-                    onChange={(e) => setEmail(e.target.value)}
-                    required
-                  />
-                </div>
-                <div className="space-y-2">
-                  <Label htmlFor="signup-username">Username</Label>
-                  <Input
-                    id="signup-username"
-                    type="text"
-                    placeholder="Choose a username"
-                    value={username}
-                    onChange={(e) => setUsername(e.target.value)}
-                    required
-                    minLength={3}
-                    maxLength={20}
-                    pattern="[a-zA-Z0-9_-]+"
-                    title="Username can only contain letters, numbers, underscores, and hyphens"
-                  />
-                  {username.length > 0 && (
-                    <div className="text-sm">
-                      {checkingUsername ? (
-                        <span className="text-muted-foreground">Checking availability...</span>
-                      ) : usernameAvailable === true ? (
-                        <span className="text-green-600">✓ Username available</span>
-                      ) : usernameAvailable === false ? (
-                        <span className="text-red-600">✗ Username already taken</span>
-                      ) : username.length < 3 ? (
-                        <span className="text-muted-foreground">Username must be at least 3 characters</span>
-                      ) : null}
-                    </div>
-                  )}
-                </div>
-                <div className="space-y-2">
-                  <Label htmlFor="signup-password">Password</Label>
-                  <Input
-                    id="signup-password"
-                    type="password"
-                    placeholder="Create a password"
-                    value={password}
-                    onChange={(e) => setPassword(e.target.value)}
-                    required
-                    minLength={6}
-                  />
-                </div>
-                <Button type="submit" className="w-full" disabled={loading || usernameAvailable === false}>
-                  {loading ? "Creating account..." : "Create Account"}
-                </Button>
-              </form>
-            </TabsContent>
-          </Tabs>
+          <TabsList className="grid w-full grid-cols-2">
+            <TabsTrigger value="signin">Sign In</TabsTrigger>
+            <TabsTrigger value="signup">Sign Up</TabsTrigger>
+          </TabsList>
+
+          <TabsContent value="signin">
+            {!showResetForm ? (
+              <SignInForm
+                onSuccess={onAuthSuccess}
+                onForgotPassword={() => setShowResetForm(true)}
+              />
+            ) : (
+              <PasswordResetForm onBack={() => setShowResetForm(false)} />
+            )}
+          </TabsContent>
+
+          <TabsContent value="signup">
+            <SignUpForm />
+          </TabsContent>
+        </Tabs>
         </CardContent>
       </Card>
     </div>

--- a/src/components/auth/PasswordResetForm.tsx
+++ b/src/components/auth/PasswordResetForm.tsx
@@ -1,0 +1,66 @@
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { resetPassword } from '@/services/authService';
+import useAuthForm from '@/hooks/useAuthForm';
+
+interface PasswordResetFormProps {
+  onBack: () => void;
+}
+
+export default function PasswordResetForm({ onBack }: PasswordResetFormProps) {
+  const { loading, setLoading, toast, showError } = useAuthForm();
+  const [email, setEmail] = useState('');
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLoading(true);
+    try {
+      const { error } = await resetPassword(email, `${window.location.origin}/`);
+      if (error) {
+        showError('Reset failed', error.message);
+      } else {
+        toast({
+          title: 'Reset email sent',
+          description: 'Check your email for password reset instructions.',
+        });
+        onBack();
+        setEmail('');
+      }
+    } catch {
+      showError('Error', 'An unexpected error occurred');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div className="space-y-2">
+        <Label htmlFor="reset-email">Email</Label>
+        <Input
+          id="reset-email"
+          type="email"
+          placeholder="Enter your email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          required
+        />
+      </div>
+      <Button type="submit" className="w-full" disabled={loading}>
+        {loading ? 'Sending reset email...' : 'Send Reset Email'}
+      </Button>
+      <div className="text-center">
+        <Button
+          type="button"
+          variant="link"
+          className="text-sm text-muted-foreground"
+          onClick={onBack}
+        >
+          Back to sign in
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/src/components/auth/SignInForm.tsx
+++ b/src/components/auth/SignInForm.tsx
@@ -1,0 +1,74 @@
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { signIn } from '@/services/authService';
+import useAuthForm from '@/hooks/useAuthForm';
+
+interface SignInFormProps {
+  onSuccess: () => void;
+  onForgotPassword: () => void;
+}
+
+export default function SignInForm({ onSuccess, onForgotPassword }: SignInFormProps) {
+  const { loading, setLoading, showError } = useAuthForm();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLoading(true);
+    try {
+      const { error } = await signIn(email, password);
+      if (error) {
+        showError('Sign in failed', error.message);
+      } else {
+        onSuccess();
+      }
+    } catch {
+      showError('Error', 'An unexpected error occurred');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div className="space-y-2">
+        <Label htmlFor="signin-email">Email</Label>
+        <Input
+          id="signin-email"
+          type="email"
+          placeholder="Enter your email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          required
+        />
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor="signin-password">Password</Label>
+        <Input
+          id="signin-password"
+          type="password"
+          placeholder="Enter your password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          required
+        />
+      </div>
+      <Button type="submit" className="w-full" disabled={loading}>
+        {loading ? 'Signing in...' : 'Sign In'}
+      </Button>
+      <div className="text-center">
+        <Button
+          type="button"
+          variant="link"
+          className="text-sm text-muted-foreground"
+          onClick={onForgotPassword}
+        >
+          Forgot your password?
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/src/components/auth/SignUpForm.tsx
+++ b/src/components/auth/SignUpForm.tsx
@@ -1,0 +1,140 @@
+import { useState, useEffect } from 'react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { signUp } from '@/services/authService';
+import useAuthForm from '@/hooks/useAuthForm';
+
+export default function SignUpForm() {
+  const { loading, setLoading, toast, showError } = useAuthForm();
+  const [email, setEmail] = useState('');
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [usernameAvailable, setUsernameAvailable] = useState<boolean | null>(null);
+  const [checkingUsername, setCheckingUsername] = useState(false);
+
+  const checkUsernameAvailability = async (usernameToCheck: string) => {
+    if (usernameToCheck.length < 3) {
+      setUsernameAvailable(null);
+      return;
+    }
+    setCheckingUsername(true);
+    try {
+      const { UserProfileService } = await import('@/services/userProfileService');
+      const { data: isAvailable } = await UserProfileService.isUsernameAvailable(usernameToCheck);
+      setUsernameAvailable(isAvailable);
+    } catch {
+      setUsernameAvailable(null);
+    } finally {
+      setCheckingUsername(false);
+    }
+  };
+
+  useEffect(() => {
+    const timeoutId = setTimeout(() => {
+      if (username.trim()) {
+        checkUsernameAvailability(username.trim());
+      } else {
+        setUsernameAvailable(null);
+      }
+    }, 500);
+    return () => clearTimeout(timeoutId);
+  }, [username]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    if (!username.trim()) {
+      showError('Username required', 'Please enter a username');
+      return;
+    }
+    if (username.trim().length < 3) {
+      showError('Username too short', 'Username must be at least 3 characters long');
+      return;
+    }
+    if (usernameAvailable === false) {
+      showError('Username unavailable', 'Please choose a different username');
+      return;
+    }
+
+    setLoading(true);
+    try {
+      const redirectUrl = `${window.location.origin}/`;
+      const { error } = await signUp(email, password, username.trim(), redirectUrl);
+      if (error) {
+        showError('Sign up failed', error.message);
+      } else {
+        toast({
+          title: 'Check your email',
+          description: "We've sent you a confirmation link to complete your registration.",
+        });
+        setEmail('');
+        setUsername('');
+        setPassword('');
+      }
+    } catch {
+      showError('Error', 'An unexpected error occurred');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div className="space-y-2">
+        <Label htmlFor="signup-email">Email</Label>
+        <Input
+          id="signup-email"
+          type="email"
+          placeholder="Enter your email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          required
+        />
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor="signup-username">Username</Label>
+        <Input
+          id="signup-username"
+          type="text"
+          placeholder="Choose a username"
+          value={username}
+          onChange={(e) => setUsername(e.target.value)}
+          required
+          minLength={3}
+          maxLength={20}
+          pattern="[a-zA-Z0-9_-]+"
+          title="Username can only contain letters, numbers, underscores, and hyphens"
+        />
+        {username.length > 0 && (
+          <div className="text-sm">
+            {checkingUsername ? (
+              <span className="text-muted-foreground">Checking availability...</span>
+            ) : usernameAvailable === true ? (
+              <span className="text-green-600">✓ Username available</span>
+            ) : usernameAvailable === false ? (
+              <span className="text-red-600">✗ Username already taken</span>
+            ) : username.length < 3 ? (
+              <span className="text-muted-foreground">Username must be at least 3 characters</span>
+            ) : null}
+          </div>
+        )}
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor="signup-password">Password</Label>
+        <Input
+          id="signup-password"
+          type="password"
+          placeholder="Create a password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          required
+          minLength={6}
+        />
+      </div>
+      <Button type="submit" className="w-full" disabled={loading || usernameAvailable === false}>
+        {loading ? 'Creating account...' : 'Create Account'}
+      </Button>
+    </form>
+  );
+}

--- a/src/hooks/useAuthForm.ts
+++ b/src/hooks/useAuthForm.ts
@@ -1,0 +1,15 @@
+import { useState } from 'react';
+import { useToast } from '@/hooks/use-toast';
+
+export function useAuthForm() {
+  const [loading, setLoading] = useState(false);
+  const { toast } = useToast();
+
+  const showError = (title: string, description: string) => {
+    toast({ variant: 'destructive', title, description });
+  };
+
+  return { loading, setLoading, toast, showError };
+}
+
+export default useAuthForm;


### PR DESCRIPTION
## Summary
- Split monolithic `AuthForm` into `SignInForm`, `SignUpForm`, and `PasswordResetForm`
- Centralize auth form state and toast handling with new `useAuthForm` hook
- Mark auth form refactor task complete in plan

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b23894b2108328ade39dfee1323edd