### PR TITLE
Normalize usernames to lowercase for availability checks

### DIFF
--- a/docs/plan.md
+++ b/docs/plan.md
@@ -170,12 +170,12 @@
         - Ensure consistent validation between UserProfileForm and UsernameChangeForm
         - Fix updateProfile method call to handle username changes properly
     
-    17.5. [ ] Verify database constraints and service validation
+    17.5. [~] Verify database constraints and service validation
         - PROBLEM: Need to confirm database unique constraints work correctly
         - Test that multiple users cannot have the same username
         - Verify server-side validation matches client-side validation
         - Test username update triggers in database (for templates table)
-        - Confirm case-sensitivity handling for usernames
+        - [x] Confirm case-sensitivity handling for usernames
     
     17.6. [ ] Add comprehensive error handling and user feedback
         - Add specific error messages for different username validation failures

--- a/src/services/userProfileService.case.test.ts
+++ b/src/services/userProfileService.case.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect, vi } from 'vitest';
+import { UserProfileService } from './userProfileService';
+
+describe('UserProfileService case-insensitive username availability', () => {
+  it('treats usernames case-insensitively', async () => {
+    const existingProfile = {
+      id: 'profile-123',
+      user_id: 'user-123',
+      username: 'testuser'
+    };
+
+    const getProfileSpy = vi
+      .spyOn(UserProfileService, 'getProfileByUsername')
+      .mockResolvedValue({ data: existingProfile, error: null });
+
+    const result = await UserProfileService.isUsernameAvailable('TestUser');
+
+    expect(getProfileSpy).toHaveBeenCalledWith('testuser');
+    expect(result).toEqual({ data: false, error: null });
+
+    getProfileSpy.mockRestore();
+  });
+});

--- a/src/services/userProfileService.ts
+++ b/src/services/userProfileService.ts
@@ -11,10 +11,15 @@ export class UserProfileService {
    * Create a new user profile
    */
   static async createProfile(profile: UserProfileInsert): Promise<{ data: UserProfile | null; error: { message: string } | null }> {
+    const normalizedProfile = {
+      ...profile,
+      username: profile.username?.toLowerCase(),
+    };
+
     return handleRequest(
       supabase
         .from('user_profiles')
-        .insert(profile)
+        .insert(normalizedProfile)
         .select()
         .single(),
       'Failed to create user profile'
@@ -68,7 +73,7 @@ export class UserProfileService {
    * Update username for a user
    */
   static async updateUsername(userId: string, newUsername: string): Promise<{ data: UserProfile | null; error: { message: string } | null }> {
-    const username = newUsername.trim();
+    const username = newUsername.trim().toLowerCase();
 
     if (!username) {
       return {
@@ -111,7 +116,8 @@ export class UserProfileService {
    */
   static async isUsernameAvailable(username: string, excludeUserId?: string): Promise<{ data: boolean; error: { message: string } | null }> {
     try {
-      const { data: existingProfile } = await this.getProfileByUsername(username);
+      const normalized = username.toLowerCase();
+      const { data: existingProfile } = await this.getProfileByUsername(normalized);
       
       if (!existingProfile) {
         return { data: true, error: null };
@@ -136,7 +142,7 @@ export class UserProfileService {
    */
   static generateDefaultUsername(email: string): string {
     const baseUsername = email.split('@')[0];
-    return baseUsername.replace(/[^a-zA-Z0-9_-]/g, '_');
+    return baseUsername.replace(/[^a-zA-Z0-9_-]/g, '_').toLowerCase();
   }
 
   /**


### PR DESCRIPTION
## Summary
- Normalize usernames to lowercase when creating profiles and updating usernames
- Ensure availability checks use lowercase to avoid case-sensitive duplicates
- Mark plan progress for database validation work

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b2b25e91b48328af94bf296a60a66a