### PR TITLE
test: add singleton test for useTemplateService

### DIFF
--- a/src/hooks/useServices.test.ts
+++ b/src/hooks/useServices.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockInstance = {};
+const TemplateServiceMock = vi.fn(() => mockInstance);
+vi.mock('../services/templateService', () => ({
+  TemplateService: TemplateServiceMock,
+}));
+vi.mock('../integrations/supabase/client', () => ({
+  supabase: {},
+}));
+
+describe('useTemplateService', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    TemplateServiceMock.mockClear();
+  });
+
+  it('returns the same TemplateService instance on subsequent calls', async () => {
+    const { useTemplateService } = await import('./useServices');
+
+    const first = useTemplateService();
+    const second = useTemplateService();
+
+    expect(first).toBe(mockInstance);
+    expect(second).toBe(mockInstance);
+    expect(TemplateServiceMock).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- add test verifying useTemplateService returns a singleton TemplateService instance

## Testing
- `npm test -- --coverage`
- `npx eslint src/hooks/useServices.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b2b7c9e8a88328af08bf527ab70ccb